### PR TITLE
fix: add exactextract and required packages to Docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@ FROM ghcr.io/osgeo/gdal:ubuntu-full-3.10.0
 
 # Install necessary tools and Python packages
 RUN apt-get update && \
-    apt-get install -y python3-pip pipenv && \
+    apt-get install -y python3-pip pipenv gcc cmake libgeos-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ GDAL==3.10.0
 azure-storage-blob
 overturemaps
 async
+exactextract


### PR DESCRIPTION
According to the [documentation](https://isciences.github.io/exactextract/installation.html) of exactetract, 

- added to install gcc, cmake and libgeos-dev in Dockerfile.
- also added `exactextract` in requirements.txt



