### PR TITLE
fix: export geojson result to sdtout to allow to reuse data for other commands or save a file

### DIFF
--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -13,6 +13,7 @@ from random import choices
 from cbsurge.admin.osm import fetch_admin as fetch_osm_admin, ADMIN_LEVELS
 from cbsurge.admin.ocha import fetch_admin as fetch_ocha_admin
 import click
+import json
 
 
 class BboxParamType(click.ParamType):
@@ -84,8 +85,13 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     the Overpass query. Additionally, all hierarchically superior admin levels and names are returned and attributes of
     the admin units.
 
+    To save the result as a file, for instance, the following command can be executed to extract admin 0 data for Rwanda and Burundi as GeoJSON file:
+
+    python -m  cbsurge.cli admin osm -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 > osm.geojson
     """
-    fetch_osm_admin(bbox=bbox, admin_level=admin_level,osm_level=osm_level, clip=clip, h3id_precision=h3id_precision)
+    geojson = fetch_osm_admin(bbox=bbox, admin_level=admin_level,osm_level=osm_level, clip=clip, h3id_precision=h3id_precision)
+    if geojson:
+        click.echo(json.dumps(geojson))
 
 @admin.command(no_args_is_help=True)
 @click.option('-b', '--bbox', required=True, type=BboxParamType(), help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north')
@@ -124,6 +130,10 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7):
     this function also uses a per country approach to fetch features and merge them into one layer in case the supplied
     bounding box covers several countries.
 
-    """
-    fetch_ocha_admin(bbox=bbox, admin_level=admin_level, clip=clip, h3id_precision=h3id_precision)
+    To save the result as a file, for instance, the following command can be executed to extract admin 0 data for Rwanda and Burundi as GeoJSON file:
 
+    python -m  cbsurge.cli admin ocha -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 > ocha.geojson
+    """
+    geojson = fetch_ocha_admin(bbox=bbox, admin_level=admin_level, clip=clip, h3id_precision=h3id_precision)
+    if geojson:
+        click.echo(json.dumps(geojson))


### PR DESCRIPTION
fixes #79

result can be saved as the following commands

```
python -m  cbsurge.cli admin osm -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 > osm.geojson
python -m  cbsurge.cli admin ocha -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 > ocha.geojson
```

or it can be piped to ogr or tippecanoe (any commands)