### PR TITLE
improved arg parsing

### DIFF
--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -8,29 +8,13 @@
 # asyncio.run(http_get_json(OCHA_COD_ARCGIS_SERVER_ROOT, timeout=10))
 # asyncio.run(http_get_json(OVERPASS_API_URL, timeout=10))
 #
-from random import choices
 
+import logging
 from cbsurge.admin.osm import fetch_admin as fetch_osm_admin, ADMIN_LEVELS
 from cbsurge.admin.ocha import fetch_admin as fetch_ocha_admin
 import click
 
 
-class BboxParamType(click.ParamType):
-    name = "bbox"
-
-    def convert(self, value, param, ctx):
-        try:
-            bbox = [float(x.strip()) for x in value.split(",")]
-            fail = False
-        except ValueError:  # ValueError raised when passing non-numbers to float()
-            fail = True
-
-        if fail or len(bbox) != 4:
-            self.fail(
-                f"bbox must be 4 floating point numbers separated by commas. Got '{value}'"
-            )
-
-        return bbox
 
 
 @click.group()
@@ -40,10 +24,11 @@ def admin():
 
 
 @admin.command(no_args_is_help=True)
-@click.option('-b', '--bbox', required=True, type=BboxParamType(), help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north')
+@click.option('-b', '--bbox', required=True, type=float,
+              help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north', nargs=4 )
 @click.option('-l','--admin_level',
                 required=True,
-                type=click.Choice(choices=['0','1','2'], case_sensitive=False),
+                type=click.IntRange(min=0, max=2, clamp=False),
                 help='UNDP admin level from where to extract the admin features'
                 )
 @click.option('-o', '--osm_level',
@@ -64,8 +49,15 @@ def admin():
     show_default=True,
     help="Precision level for H3 indexing (default is 7)."
 )
+@click.option('--debug',
 
-def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7):
+    is_flag=True,
+    default=False,
+    help="Set log level to debug"
+)
+
+
+def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7, debug=False):
     """
     Fetch admin boundaries from OSM
 
@@ -85,13 +77,17 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     the admin units.
 
     """
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
     fetch_osm_admin(bbox=bbox, admin_level=admin_level,osm_level=osm_level, clip=clip, h3id_precision=h3id_precision)
 
+
+
 @admin.command(no_args_is_help=True)
-@click.option('-b', '--bbox', required=True, type=BboxParamType(), help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north')
+@click.option('-b', '--bbox', required=True, type=float,
+              help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north', nargs=4)
 @click.option('-l','--admin_level',
                 required=True,
-                type=click.Choice(choices=['0','1','2'], case_sensitive=False),
+                type=click.IntRange(min=0, max=2, clamp=False),
                 help='UNDP admin level from where to extract the admin features'
                 )
 
@@ -108,8 +104,14 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     show_default=True,
     help="Precision level for H3 indexing (default is 7)."
 )
+@click.option('--debug',
 
-def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7):
+    is_flag=True,
+    default=False,
+    help="Set log level to debug"
+)
+
+def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, debug=False):
     """
     Fetch admin boundaries from OCHA COD
 
@@ -125,5 +127,6 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7):
     bounding box covers several countries.
 
     """
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
     fetch_ocha_admin(bbox=bbox, admin_level=admin_level, clip=clip, h3id_precision=h3id_precision)
 

--- a/cbsurge/admin/ocha.py
+++ b/cbsurge/admin/ocha.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
+
 OCHA_COD_ARCGIS_SERVER_ROOT= 'https://codgis.itos.uga.edu/arcgis/rest/services'
 ARCGIS_SERVER_ROOT = 'https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services'
 ARCGIS_COD_SERVICE = 'COD_External'
@@ -183,6 +184,7 @@ def fetch_admin(bbox=None, admin_level=None, clip=False,h3id_precision=7, ):
 
 
     ocha_countries = fetch_ocha_countries()
+
     timeout = httpx.Timeout(connect=10, read=1800, write=1800, pool=1000)
     bbox_polygon = box(west, south, east, north)
     geojson = None

--- a/cbsurge/cli.py
+++ b/cbsurge/cli.py
@@ -1,9 +1,8 @@
 from cbsurge.admin import admin
 import click
-
 @click.group
-@click.pass_context
-def cli(ctx):
+
+def cli():
     """Main CLI for the application."""
     pass
 cli.add_command(admin)


### PR DESCRIPTION
This PR improves the way bbox and admin/osm levels args are handled. bbox is now of type float and requires 4 values separated by space

closes #80 