### PR TITLE
feat: added stats compute command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cbsurge/cli.py
+++ b/cbsurge/cli.py
@@ -2,6 +2,7 @@ import click as click
 
 from cbsurge.admin import admin
 from cbsurge.exposure.population import population
+from cbsurge.stats import stats
 
 
 @click.group
@@ -11,6 +12,7 @@ def cli():
     pass
 cli.add_command(admin)
 cli.add_command(population)
+cli.add_command(stats)
 
 
 if __name__ == '__main__':

--- a/cbsurge/stats/GDALRasterSource.py
+++ b/cbsurge/stats/GDALRasterSource.py
@@ -1,0 +1,83 @@
+import logging
+import os
+from osgeo import gdal
+
+
+logger = logging.getLogger(__name__)
+
+
+class GDALRasterSource:
+    """
+    The class manages raster data source and additional functionality to process.
+
+    Example:
+        with GDALRasterSource(input_raster) as raster:
+            raster.reproject_raster(output_raster, target_srs)
+    """
+
+    def __init__(self, filepath: str, is_clear: bool = False):
+        """
+        Constructor.
+
+        Parameters:
+            filepath (str): Path to the vector file
+            is_clear (bool): If True, the file will be deleted when exiting from with statement
+        """
+        self.filepath = filepath
+        self.is_clear = is_clear
+        self.datasource = None
+
+    def __enter__(self):
+        """Open the raster data source."""
+        self.dataset = gdal.Open(self.filepath)
+        if not self.dataset:
+            raise RuntimeError(f"Failed to open raster file: {self.filepath}")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Close the raster data source."""
+        if self.dataset:
+            self.dataset = None
+        if self.is_clear:
+            self.delete_file()
+
+    def delete_file(self):
+        """Delete file"""
+        if os.path.exists(self.filepath):
+            os.remove(self.filepath)
+            logger.debug(f"Deleted file: {self.filepath}")
+
+
+    def reproject(self,
+                  target_srs,
+                  resample_alg=gdal.GRA_Bilinear,
+                  data_format="GTiff"):
+        """
+        Reproject the raster file to a specified coordinate reference system.
+
+        Parameters:
+            target_srs (str): EPSG code or PROJ.4 string for the target projection.
+            resample_alg (int): Resampling algorithm (default: gdal.GRA_Bilinear).
+            data_format (str): Output raster format (default: "GTiff").
+        """
+        file_name_with_ext = os.path.basename(self.filepath)
+        raster_file = os.path.splitext(file_name_with_ext)[0]
+        reprojected_rast = f"{raster_file}_reprojected.tif"
+
+        warp_options = gdal.WarpOptions(
+            dstSRS=target_srs,
+            resampleAlg=resample_alg,
+            format=data_format
+        )
+
+        result = gdal.Warp(
+            destNameOrDestDS=reprojected_rast,
+            srcDSOrSrcDSTab=self.filepath,
+            options=warp_options
+        )
+
+        if result is None:
+            raise RuntimeError("gdal.Warp failed to reproject the raster.")
+        result = None
+        logger.debug(f"Reprojected raster saved to {reprojected_rast}")
+        return reprojected_rast

--- a/cbsurge/stats/OGRDataSource.py
+++ b/cbsurge/stats/OGRDataSource.py
@@ -1,0 +1,127 @@
+import logging
+import os
+import geopandas as gpd
+from osgeo import ogr, gdal
+
+
+logger = logging.getLogger(__name__)
+
+
+class OGRDataSource:
+    """
+    The class manages vector data source from OGR API
+
+    Example:
+        with OGRDataSource(filepath) as datasource:
+            datasource.get_fields()
+    """
+    def __init__(self, filepath: str, is_clear:bool=False):
+        """
+        Constructor.
+
+        Parameters:
+            filepath (str): Path to the vector file
+            is_clear (bool): If True, the file will be deleted when exiting from with statement
+        """
+        self.filepath = filepath
+        self.is_clear = is_clear
+        self.datasource = None
+
+    def __enter__(self):
+        self.datasource = ogr.Open(self.filepath)
+        if not self.datasource:
+            raise RuntimeError(f"Failed to open vector file: {self.filepath}")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.datasource:
+            self.datasource = None
+        if self.is_clear:
+            self.delete_file()
+
+    def delete_file(self):
+        """Delete file"""
+        if os.path.exists(self.filepath):
+            os.remove(self.filepath)
+            logger.debug(f"Deleted file {self.filepath}")
+
+
+    def get_layer(self):
+        """Get the layer from the vector data source."""
+        return self.datasource.GetLayer()
+
+    def clean(self):
+        """
+        clean dataset before doing zonal stats
+        """
+        gdf = gpd.read_file(self.filepath)
+
+        for column in gdf.columns:
+            dtype = gdf[column].dtype
+            if dtype == 'object':
+                gdf[column] = gdf[column].astype(str)
+            elif dtype == 'int64':
+                gdf[column] = gdf[column].astype('float64')
+
+        dir_name = os.path.dirname(self.filepath)
+        file, ext = self.split_filename(self.filepath)
+        output_file = f"{dir_name}/{file}_cleaned.{ext}"
+
+        gdf.to_file(output_file, driver="GeoJSON")
+
+        return output_file
+
+    def get_fields(self):
+        """Get a list of field names from the vector dataset."""
+        layer = self.get_layer()
+        if not layer:
+            raise RuntimeError(f"Failed to access layer in vector file: {self.filepath}")
+
+        layer_def = layer.GetLayerDefn()
+        field_names = [layer_def.GetFieldDefn(i).GetName() for i in range(layer_def.GetFieldCount())]
+        return field_names
+
+    def reproject(self,
+                  target_srs,
+                  src_srs=None,
+                  data_format="FlatGeobuf",
+                  output_file=None):
+        """
+        Reproject the vector file to FlatGeobuf format with a specified coordinate reference system.
+
+        Parameters:
+            target_srs (str): EPSG code or PROJ.4 string for the target projection.
+            src_srs (str): EPSG code or PROJ.4 string for the source projection (optional).
+            data_format (str): The format to use (defaults to "FlatGeobuf").
+            output_file (str): Optional. Path to save the reprojected vector file if specified. Otherwise, it creates a new file with _reprojected suffix.
+        """
+        if not output_file:
+            vector_file = self.split_filename(self.filepath)[0]
+            output_file = f"{vector_file}_reprojected.fgb"
+
+        translate_options = gdal.VectorTranslateOptions(
+            format=data_format,
+            dstSRS=target_srs,
+            srcSRS=src_srs,
+            layerName=self.split_filename(output_file)[0]
+        )
+
+        gdal.VectorTranslate(
+            destNameOrDestDS=output_file,
+            srcDS=self.datasource,
+            options=translate_options,
+        )
+        logger.debug(f"Reprojected vector saved to {output_file} in {format} format")
+        return output_file
+
+    def split_filename(self, filename):
+        """
+        Split file name from extension
+
+        Returns:
+            It returns an array which contains filename without extension, extension
+        """
+        file_name_with_ext = os.path.basename(filename)
+        file_name_without_ext = os.path.splitext(file_name_with_ext)[0]
+        ext = os.path.splitext(file_name_with_ext)[1]
+        return [file_name_without_ext, ext]

--- a/cbsurge/stats/ZonalStats.py
+++ b/cbsurge/stats/ZonalStats.py
@@ -1,0 +1,143 @@
+import logging
+import os
+from exactextract import exact_extract
+from cbsurge.stats.GDALRasterSource import GDALRasterSource
+from cbsurge.stats.OGRDataSource import OGRDataSource
+
+
+logger = logging.getLogger(__name__)
+
+
+class ZonalStats:
+    def __init__(self, input_file: str, target_srid: int=54009):
+        """
+        constructor
+
+        parameters:
+            input_file: path to input file
+            target_srs: target spatial resolution in EPSG code. Default is 54009 (Mollweide projection https://epsg.io/54009).
+        """
+        self.input_file = input_file
+        self.target_srid = target_srid
+        self.gdf = None
+        logger.debug(f"input_file: {self.input_file}, target_srs: {self.target_srid}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.input_file = None
+        self.target_srid = None
+        self.gdf = None
+
+    def get_src(self, srid: int):
+        """
+        get src definition from srid
+
+        Parameters:
+            srid: EPSG code
+        """
+        target_srs = f"EPSG:{str(srid)}"
+        # Some EPSG code like Mollweide is not defined in GDAL Python API, thus it can convert it to proj.4 string manually if necessary
+        if srid == 54009:
+            # Mollweide projection https://epsg.io/54009
+            target_srs = '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs'
+        return target_srs
+
+    def compute(self, raster: str, operations: list = None, operation_cols: list = None):
+        """
+        compute zonal statistics with given raster file.
+
+        Parameters:
+            raster: path to raster file
+            operations:
+                list of operations to compute.
+                See available operations at https://isciences.github.io/exactextract/operations.html
+            operation_cols:
+                list of column names for each operation. The number of columns must match the number of operations.
+                If this option is not specified, raster file name is used as prefix of column names.
+                For example, if aaa.tif is specified, column name will be 'aaa_sum'.
+        Returns:
+            geopandas dataframe with zonal statistics
+        """
+        logger.info(f"start computing zonal statistics for {raster}")
+        if operations is None or len(operations) == 0:
+            raise RuntimeError(f"at least one operation must be specified")
+
+        if operation_cols is not None and len(operation_cols) != len(operations):
+            raise RuntimeError(f"The number of operation columns must match the number of operations.")
+
+        target_srs = self.get_src(self.target_srid)
+
+        # raster
+        with GDALRasterSource(raster) as raster_ds:
+            reprojected_rast = raster_ds.reproject(target_srs)
+            logger.debug(f"raster ({raster}) was reprojected to {self.target_srid} as {reprojected_rast}")
+
+            with OGRDataSource(self.input_file) as cleaned_ds:
+                cleaned_input_file = cleaned_ds.clean()
+                logger.debug(f"Input file was cleaned as {cleaned_input_file}")
+                # vector
+                with OGRDataSource(filepath=cleaned_input_file, is_clear=True) as vector_ds:
+                    vector_fields = vector_ds.get_fields()
+                    reprojected_vector_path = vector_ds.reproject(
+                        target_srs=target_srs,
+                        data_format='FlatGeobuf')
+                    logger.debug(f"vector ({cleaned_input_file}) was reprojected to {self.target_srid} as {reprojected_vector_path}")
+
+                    self.gdf = exact_extract(
+                        reprojected_rast,
+                        reprojected_vector_path,
+                        ops=operations,
+                        include_cols=vector_fields,
+                        include_geom=True,
+                        output="pandas"
+                    )
+
+                    raster_name_with_ext = os.path.basename(raster)
+                    raster_file_name = os.path.splitext(raster_name_with_ext)[0]
+
+                    for index, ope in enumerate(operations):
+                        column_name = ope
+                        if column_name in self.gdf.columns:
+                            new_col_name = f"{raster_file_name}_{column_name}"
+                            if operation_cols is not None:
+                                new_col_name = operation_cols[index]
+                            self.gdf.rename(columns={column_name: new_col_name}, inplace=True)
+
+                    os.remove(reprojected_rast)
+                    logger.debug(f"deleted {reprojected_rast}")
+                    os.remove(reprojected_vector_path)
+                    logger.debug(f"deleted {reprojected_vector_path}")
+                    logger.info(f"end computing zonal statistics for {raster}")
+                    return self.gdf
+
+    def write(self, output_file, target_srid: int = 3857):
+        """
+        write zonal statistics to output file.
+        compute method must be executed prior to calling this method.
+
+        Parameters:
+            output_file: path to output file. Only supports .shp, .gpkg, .fgb, .geojson currently.
+            target_srid: target spatial resolution in EPSG code. Default is 3857
+        """
+        if self.gdf is None:
+            raise RuntimeError(f"execute compute() method first to compute ZonalStats.")
+        gdf_copy = self.gdf.copy()
+        if target_srid:
+            target_srs = self.get_src(target_srid)
+            gdf_copy = gdf_copy.to_crs(target_srs)
+
+        driver = None
+        if output_file.endswith(".shp"):
+            driver = "ESRI Shapefile"
+        elif output_file.endswith(".gpkg"):
+            driver = "GPKG"
+        elif output_file.endswith(".fgb"):
+            driver = "FlatGeobuf"
+        elif output_file.endswith(".geojson"):
+            driver = "GeoJSON"
+        else:
+            raise RuntimeError(f"unsupported output file type: {output_file}")
+        gdf_copy.to_file(output_file, driver=driver)
+        logger.info(f"Saved stats to {output_file}")

--- a/cbsurge/stats/__init__.py
+++ b/cbsurge/stats/__init__.py
@@ -1,0 +1,86 @@
+import logging
+import click
+from cbsurge.stats.ZonalStats import ZonalStats
+
+
+@click.group()
+def stats():
+    f"""Command line interface for {__package__} package"""
+    pass
+@stats.command(no_args_is_help=True)
+@click.option('-i', '--input',
+              required=True,
+              type=str,
+              help='Input vector file'
+              )
+@click.option('-r', '--raster',
+              required=True,
+              type = str,
+              help='Input raster file'
+              )
+@click.option('-d','--dist',
+              required=True,
+              type=str,
+              help='Output vector file'
+              )
+@click.option('-o', '--operation',
+              required=True,
+              multiple=True,
+              type=click.Choice([
+                  'cell_id', 'center_x', 'center_y', 'coefficient_of_variation', 'count',
+                  'coverage', 'frac', 'majority', 'max', 'max_center_x', 'max_center_y',
+                  'mean', 'median', 'min', 'min_center_x', 'min_center_y',
+                  'minority', 'quantile', 'stdev', 'sum', 'unique',
+                  'values', 'variance', 'variety', 'weighted_frac','weighted_mean',
+                  'weighted_stdev', 'weighted_sum', 'weighted_variance', 'weights'
+              ], case_sensitive=True),
+              help=
+              """
+              Operations to perform (e.g., "sum", "mean", "count"). Can be specified multiple times. 
+              See all available operations at https://isciences.github.io/exactextract/operations.html
+              """
+              )
+@click.option('-c', '--column',
+              required=False,
+              multiple=True,
+              help=
+              """
+              list of column names for each operation. The number of columns must match the number of operations.
+              If this option is not specified, raster file name is used as prefix of column names.
+              For example, if aaa.tif is specified, column name will be 'aaa_sum'.
+              """
+              )
+@click.option('-s','--srid',
+              required=False,
+              type=int,
+              help='SRID for output vector file. Default is 3857',
+              )
+@click.option('--debug',
+              is_flag=True,
+              default=False,
+              help="Set log level to debug"
+              )
+def compute(
+        input=None,
+        raster=None,
+        srid=3857,
+        dist=None,
+        operation=None,
+        column=None,
+        debug=False):
+    """
+    This command compute zonal statistics with given raster file from a vector file, and save the result to output file.
+
+    output file format supports Shapefile (.shp), GeoJSON (.geojson), FlatGeobuf (.fgb) and GeoPackage (.gpkg)
+
+    Usage:
+        The below command provides how to use the command to compute zonal statistics.
+        python -m cbsurge.cli stats compute --help
+
+    Example:
+        python -m cbsurge.cli stats compute -i ./osm_admin2.geojson -r ./rwa_f_0_2020_constrained_UNadj.tif -d ./osm_admin2_stats.fgb -o sum -o median -c female_sum -c female_median
+    """
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
+    with ZonalStats(input, target_srid=54009) as st:
+        st.compute(raster, operations=operation, operation_cols=column)
+        st.write(dist, target_srid=srid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ click
 pyarrow
 azure-core
 rasterio
+geopandas


### PR DESCRIPTION
closes #66 

Zonal stats can be performed by the following command example.

```shell
python -m cbsurge.cli stats compute -i ./osm_admin2.geojson -r ./rwa_f_0_2020_constrained_UNadj.tif -d ./osm_admin2_stats.fgb -o sum -o median -c female_sum -c female_median
```

To Do:

I still want to change following thing before merging. 

- accept multiple `--raster` option to compute zonal stats

Usage: 

```shell
pipenv run python -m cbsurge.cli stats compute --help
Usage: python -m cbsurge.cli stats compute [OPTIONS]

  This command compute zonal statistics with given raster file from a vector
  file, and save the result to output file.

  output file format supports Shapefile (.shp), GeoJSON (.geojson), FlatGeobuf
  (.fgb) and GeoPackage (.gpkg)

  Usage:     The below command provides how to use the command to compute
  zonal statistics.     python -m cbsurge.cli stats compute --help

  Example:     python -m cbsurge.cli stats compute -i ./osm_admin2.geojson -r
  ./rwa_f_0_2020_constrained_UNadj.tif -d ./osm_admin2_stats.fgb -o sum -o
  median -c female_sum -c female_median

Options:
  -i, --input TEXT                Input vector file  [required]
  -r, --raster TEXT               Input raster file  [required]
  -d, --dist TEXT                 Output vector file  [required]
  -o, --operation [cell_id|center_x|center_y|coefficient_of_variation|count|coverage|frac|majority|max|max_center_x|max_center_y|mean|median|min|min_center_x|min_center_y|minority|quantile|stdev|sum|unique|values|variance|variety|weighted_frac|weighted_mean|weighted_stdev|weighted_sum|weighted_variance|weights]
                                  Operations to perform (e.g., "sum", "mean",
                                  "count"). Can be specified multiple times.
                                  See all available operations at https://isci
                                  ences.github.io/exactextract/operations.html
                                  [required]
  -c, --column TEXT               list of column names for each operation. The
                                  number of columns must match the number of
                                  operations. If this option is not specified,
                                  raster file name is used as prefix of column
                                  names. For example, if aaa.tif is specified,
                                  column name will be 'aaa_sum'.
  -s, --srid INTEGER              SRID for output vector file. Default is 3857
  --debug                         Set log level to debug
  --help                          Show this message and exit.
```