### PR TITLE
share venv with other users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,16 @@ jobs:
           mkdir -p "$CACHE_DIR"
           docker save ${{ steps.image_tag.outputs.TAG }} > ${{ steps.image_tag.outputs.TAR_PATH }}
 
+      - name: Install dependencies in container
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash my-app:latest -c "
+            export LANG=C.UTF-8 && pipenv install -e .
+          "
       - name: Run tests in container
         run: |
           # Change owner of workspace to ubuntu user
           sudo chown -R 1000:1000 ${{ github.workspace }}
-          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash ${{ steps.image_tag.outputs.TAG }} -c "cd /app && make test"
+          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash ${{ steps.image_tag.outputs.TAG }} -c "make test"
 
   deploy-acr:
     name: Build and deploy to Azure Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           # Change owner of workspace to ubuntu user
           sudo chown -R 1000:1000 ${{ github.workspace }}
-          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash ${{ steps.image_tag.outputs.TAG }} -c "make test"
+          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash ${{ steps.image_tag.outputs.TAG }} -c "cd /app && make test"
 
   deploy-acr:
     name: Build and deploy to Azure Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install dependencies in container
         run: |
-          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash my-app:latest -c "
+          docker run --rm -v ${{ github.workspace }}:/app -w /app --entrypoint /bin/bash ${{ steps.image_tag.outputs.TAG }} -c "
             export LANG=C.UTF-8 && pipenv install -e .
           "
       - name: Run tests in container

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN chmod +x /app/create_user.sh
 RUN chmod +x /app/entrypoint.sh
 
 # install package
-RUN pipenv --python 3 && pipenv run pip install -e .
+ENV PIPENV_VENV_IN_PROJECT=1
+RUN pipenv install --dev --python 3 && \
+    pipenv run pip install -e .
+ENV VIRTUAL_ENV=/app/.venv
 
 EXPOSE 22
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The below command is connecting to `localhost` with user `docker` through port `
 ```shell
 ssh docker@localhost -p 2222
 
-# make sure installing the package first
-cd /app
-pipenv run pip install -e .
+# it will automatically enter venv in /app folder
+# then run rapida command
+rapida --help
 ```
 
 ### destroy docker container

--- a/create_user.sh
+++ b/create_user.sh
@@ -20,8 +20,7 @@ else
     # Grant sudo access (optional)
     usermod -aG sudo "$USERNAME"
     echo "User $USERNAME granted sudo privileges."
-fi
 
-# Set ownership of /app folder to the user
-chown -R "$USERNAME:$USERNAME" /app
-echo "Ownership of /app granted to $USERNAME."
+    echo "cd /app; pipenv shell;" >> /home/$USERNAME/.bashrc
+    echo "User $USERNAME profile was modified to launch venv in starting."
+fi


### PR DESCRIPTION
fixes #102 

it is not installing globally, but use `PIPENV_VENV_IN_PROJECT=1` variable to install venv under `/app` folder, so all users can share same environment.

I added a command in bashrc to automatically move to `/app` to run `pipenv shell`, so basically `rapida` command is available anywhere unless users exit