### PR TITLE
fix: add missing dependencies to pyproject.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GROUPNAME="cbsurge"
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get update && \
     apt-get install -y python3-pip pipenv \
-        gcc cmake libgeos-dev \
+        gcc cmake libgeos-dev git \
         openssh-server \
         ca-certificates curl gnupg nodejs && \
     apt-get clean && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,11 @@ dependencies = [
     "jupyterlab",
     "notebook",
     "dockerspawner",
-    "pytest"
+    "pytest",
+    "rich",
+    "morecantile",
+    "mapbox_vector_tile",
+    "aiopmtiles @ git+https://github.com/developmentseed/aiopmtiles"
 ]
 
 [project.scripts]
@@ -65,6 +69,9 @@ exclude = [
     "tests",
     "Makefile"
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
rapida command does not work because of missing dependencies