### PR TITLE
fix: delete duplicated codes from cli.py

### DIFF
--- a/cbsurge/cli.py
+++ b/cbsurge/cli.py
@@ -3,21 +3,12 @@ from cbsurge.util import setup_logger
 from cbsurge.admin import admin
 from cbsurge.initialize import init
 from cbsurge.exposure.builtenv import builtenv
-import click
-
-@click.group
-def cli(ctx):
-    """Main CLI for the application."""
-    pass
-cli.add_command(admin)
-cli.add_command(builtenv)
-
 from cbsurge.exposure.population import population
 from cbsurge.stats import stats
+import click
 
 
 @click.group
-
 def cli():
     """Main CLI for the application."""
     pass
@@ -27,7 +18,6 @@ cli.add_command(builtenv)
 cli.add_command(init)
 cli.add_command(population)
 cli.add_command(stats)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
previously I fixed cli.py to delete duplication of codes, however @iferencik reverted changes by PR https://github.com/UNDP-Data/geo-cb-surge/pull/107