### PR TITLE
feat: implement download from azure

### DIFF
--- a/cbsurge/exposure/population/__init__.py
+++ b/cbsurge/exposure/population/__init__.py
@@ -37,5 +37,5 @@ def download(country, download_path, age_group, sex, non_aggregates):
 @click.option('--sex', help='The sex (male or female) to process the data for', type=click.Choice(['male', 'female']))
 @click.option('--download-path', help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=False)
 @click.option('--force-reprocessing', help='Force reprocessing of data even if the data specified already exists', is_flag=True)
-def run_aggregate(country, age_group, sex, download_path, force_reprocessing):
+def aggregate(country, age_group, sex, download_path, force_reprocessing):
     asyncio.run(process_aggregates(country_code=country, age_group=age_group, sex=sex, download_path=download_path, force_reprocessing=force_reprocessing))

--- a/cbsurge/exposure/population/__init__.py
+++ b/cbsurge/exposure/population/__init__.py
@@ -23,12 +23,51 @@ def sync(force_reprocessing, country, download_path, all_data):
 
 
 @population.command(no_args_is_help=True)
-@click.option('--country', help='The ISO3 code of the country to process the data for')
-@click.option('--download-path', help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=True)
-@click.option('--age-group', help='The age group (child, active or elderly) to process the data for', type=click.Choice(['child', 'active', 'elderly']))
-@click.option('--sex', help='The sex (male or female) to process the data for', type=click.Choice(['male', 'female']))
-@click.option('--non-aggregates', help='Download only aggregate files', is_flag=True, default=False)
+@click.option('--country',
+              help='The ISO3 code of the country to process the data for')
+@click.option('--download-path',
+              help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=True)
+@click.option('--age-group',
+              help='The age group (child, active, elderly or total) to process the data for. total is not supported with non aggregate option',
+              type=click.Choice(['child', 'active', 'elderly', 'total']))
+@click.option('--sex',
+              help='The sex (male or female) to process the data for',
+              type=click.Choice(['male', 'female']))
+@click.option('--non-aggregates',
+              help='Download only non aggregated files (original worldpop data). Default is to download only aggregated data.',
+              is_flag=True,
+              default=False)
 def download(country, download_path, age_group, sex, non_aggregates):
+    """
+    Download population data (Cloud Optimised GeoTiff format) from UNDP Azure Blob Storage.
+
+    Usage:
+    To simply download all aggregated worldpop population data for a country, execute the command like below.
+
+        rapida population download --country={COUNTRY ISO 3 code} --download-path={DOWNLOAD_PATH}
+
+    Check country ISO code from https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes.
+
+    It downloads all data (age group (total, child, active, elderly), and sex (male, female) according to given options to the command.
+
+    If only specific sex data needs to be downloaded, use `--sex` like below.
+        rapida population download --country={COUNTRY ISO 3 code} --sex={female|male} --download-path={DOWNLOAD_PATH}
+
+
+    If only specific age data needs to be downloaded, use `--age-group` like below.
+
+        rapida population download --country={COUNTRY ISO 3 code} --age-group={child|active|elderly|total} --download-path={DOWNLOAD_PATH}
+
+    if only total data needs to be downloaded, use `--age-group=total` like below.
+
+        rapida population download --country={COUNTRY ISO 3 code} --age-group=total --download-path={DOWNLOAD_PATH}
+
+    Original worldpop populatin data is split into each age group. If you would like to download original worldpop data, please use `--non-aggregates` option
+
+        rapida population download --country={COUNTRY ISO 3 code} --download-path={DOWNLOAD_PATH} --non-aggregates
+
+    If you would like to download original data for specific conditions, use --sex or --age-group together. `--age-group=total` is not supported for non-aggregate data.
+    """
     asyncio.run(run_download(country_code=country, download_path=download_path, age_group=age_group, sex=sex, non_aggregates=non_aggregates))
 
 @population.command(no_args_is_help=True)

--- a/cbsurge/exposure/population/__init__.py
+++ b/cbsurge/exposure/population/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import click
-from sqlalchemy import True_
 
 from cbsurge.exposure.population.worldpop import population_sync, process_aggregates, run_download
 

--- a/cbsurge/exposure/population/__init__.py
+++ b/cbsurge/exposure/population/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import click
+from sqlalchemy import True_
 
 from cbsurge.exposure.population.worldpop import population_sync, process_aggregates, run_download
 
@@ -11,27 +12,31 @@ def population():
     pass
 
 
-@population.command()
-@click.option('--force-reprocessing', help='Force reprocessing of data', is_flag=True)
+@population.command(no_args_is_help=True)
+@click.option('--force-reprocessing', help='Force reprocessing of data even if the data specified already exists', is_flag=True)
 @click.option('--country', help='The ISO3 code of the country to process the data for')
-@click.option('--download-path', help='Download data locally', required=False)
-def sync(force_reprocessing, country, download_path):
-    asyncio.run(population_sync(force_reprocessing=force_reprocessing, country_code=country, download_path=download_path))
+@click.option('--download-path', help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=False)
+@click.option('--all-data', help='Sync all datasets for all countries. It should not be used together with --country flag', is_flag=True, default=False)
+def sync(force_reprocessing, country, download_path, all_data):
+    if all_data and country:
+        raise click.UsageError("The --country flag should not be used together with --all-data flag")
+    asyncio.run(population_sync(force_reprocessing=force_reprocessing, country_code=country, download_path=download_path, all_data=all_data))
 
 
-@population.command()
+@population.command(no_args_is_help=True)
 @click.option('--country', help='The ISO3 code of the country to process the data for')
-@click.option('--download-path', help='Download data locally', required=False)
-@click.option('--age-group', help='The age group to process the data for', type=click.Choice(['child', 'active', 'elderly']))
-@click.option('--sex', help='Path to the downloaded data', type=click.Choice(['male', 'female']))
-def download(country, download_path, age_group, sex):
-    asyncio.run(run_download(country_code=country, download_path=download_path, age_group=age_group, sex=sex))
+@click.option('--download-path', help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=True)
+@click.option('--age-group', help='The age group (child, active or elderly) to process the data for', type=click.Choice(['child', 'active', 'elderly']))
+@click.option('--sex', help='The sex (male or female) to process the data for', type=click.Choice(['male', 'female']))
+@click.option('--non-aggregates', help='Download only aggregate files', is_flag=True, default=False)
+def download(country, download_path, age_group, sex, non_aggregates):
+    asyncio.run(run_download(country_code=country, download_path=download_path, age_group=age_group, sex=sex, non_aggregates=non_aggregates))
 
-@population.command()
+@population.command(no_args_is_help=True)
 @click.option('--country', help='The ISO3 code of the country to process the data for')
-@click.option('--age-group', help='The age group to process the data for', type=click.Choice(['child', 'active', 'elderly']))
-@click.option('--sex', help='Path to the downloaded data', type=click.Choice(['male', 'female']))
-@click.option('--download-path', help='Download data locally', required=False)
-@click.option('--force-reprocessing', help='Force reprocessing of data', is_flag=True)
+@click.option('--age-group', help='The age group (child, active or elderly) to process the data for', type=click.Choice(['child', 'active', 'elderly']))
+@click.option('--sex', help='The sex (male or female) to process the data for', type=click.Choice(['male', 'female']))
+@click.option('--download-path', help='The local path to save the data to. If not provided, it will automatically save to the provided azure container that was set when initializing with `rapida init`', required=False)
+@click.option('--force-reprocessing', help='Force reprocessing of data even if the data specified already exists', is_flag=True)
 def run_aggregate(country, age_group, sex, download_path, force_reprocessing):
     asyncio.run(process_aggregates(country_code=country, age_group=age_group, sex=sex, download_path=download_path, force_reprocessing=force_reprocessing))

--- a/cbsurge/exposure/population/worldpop.py
+++ b/cbsurge/exposure/population/worldpop.py
@@ -271,57 +271,91 @@ async def get_links_from_table(data_id=None):
             return []
         return await extract_links_from_table(response.text)
 
-async def run_download(country_code=None, year=DATA_YEAR, download_path=None, sex=None, age_group=None, aggregate=True):
+async def run_download(country_code=None, year=DATA_YEAR, download_path=None, sex=None, age_group=None, non_aggregates=False):
     """
     Args:
 
-        country_code: The country code of the country intended to be downloaded
-        year: The year to download the data for
-        download_path: local download path
-        sex: The sex classification of the data to download
-        age_group: The age group classification of the data to download
-        aggregate: (bool) Whether to download the aggregate files
+        country_code: (Required) The country code of the country intended to be downloaded
+        year: (Not implemented) The year to download the data for
+        download_path: (Required) local download path
+        sex: (Optional) The sex classification of the data to download
+        age_group: (Optional) The age group classification of the data to download
+        non_aggregates: (bool) Whether to download the non-aggregate files only or not. Default is True (only download aggregate files)
     Returns:
 
     """
 
-    async def __construct_file_name__():
-        if aggregate:
-            # construct the path for the aggregate files based of the WORLDPOP_AGE_MAPPING and get the label from the AGESEX_STRUCTURE_COMBINATIONS
-            for combo in AGESEX_STRUCTURE_COMBINATIONS:
-                if combo["age_group"] == age_group:
-                    return f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate", f"{country_code}_{combo['label']}.tif"
+    assert country_code is not None, "country_code is required"
+    assert download_path is not None, "download_path is required"
+
+    # create the download path if it does not exist
+    if not os.path.exists(download_path):
+        logging.info("Download path does not exist. Creating download path: %s", download_path)
+        os.makedirs(download_path, exist_ok=True)
+
+    async def _get_blobs_list(c_client=None, age_group=None, sex=None):
+        """
+        Construct the file name based on the provided arguments in the parent function
+        Args:
+            c_client: The container client instance
+
+        Returns:
+
+        """
+        if not non_aggregates:
+            if sex and age_group:
+                return [f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate/{country_code}_{sex}_{age_group}.tif"]
+            elif sex:
+                return [b.name async for b in c_client.list_blobs(
+                    name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate/{country_code}_{sex}")]
+            elif age_group:
+                return list(filter(lambda y: age_group in y, list(filter(
+                    lambda x: x.startswith(f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate/{country_code}_"),
+                    [b.name async for b in
+                     c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate")]))))
+            else:
+                # all aggregates for the country_code provided
+                return [b.name async for b in
+                        c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate")]
         else:
-            # construct the path for the individual files checking where the age group falls in the WORLDPOP_AGE_MAPPING
-            pass
+            if sex and age_group:
+                return [b.name async for b in c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/{sex}/{age_group}")]
+            elif sex:
+                return [b.name async for b in c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/{sex}")]
+            elif age_group:
+                _blobs = []
+                for s in SEX_MAPPING.values():
+                    _blobs.extend([b.name async for b in c_client.list_blobs(
+                        name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/{s}/{age_group}")])
+                return _blobs
+            else:
+                return list(filter(lambda x : not x.startswith(f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate/"), [b.name async for b in c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}")]))
+
     logging.info("Starting data download from azure")
     session = Session()
     async with session.get_blob_service_client(account_name=session.get_account_name()) as blob_service_client:
         container_client = blob_service_client.get_container_client(container=session.get_container_name())
 
-        file_path, file_name = await __construct_file_name__()
+        blobs_path_list = await _get_blobs_list(c_client=container_client, age_group=age_group, sex=sex)
 
-        blob_client = container_client.get_blob_client(blob=f"{file_path}/{file_name}")
-        if download_path:
-            os.makedirs(os.path.join(download_path), exist_ok=True)
-            local_download_path = os.path.join(download_path, file_name)
-
+        for blob_path in blobs_path_list:
+            blob_client = container_client.get_blob_client(blob=blob_path)
             blob_properties = await blob_client.get_blob_properties()
             total_size = blob_properties.size
+            local_download_path = os.path.join(download_path, blob_path.split("/")[-1])
             async with aiofiles.open(local_download_path, "wb") as data:
                 blob = await blob_client.download_blob()
-                progress = tqdm_asyncio(total=total_size, unit="B", unit_scale=True, desc=file_name)
+                progress = tqdm_asyncio(total=total_size, unit="B", unit_scale=True, desc=blob_path.split("/")[-1])
                 async for chunk in blob.chunks():
                     await data.write(chunk)
                     progress.update(len(chunk))
                 progress.close()
-
-            logging.info("Download completed for blob: %s", file_name)
-        return file_name
-
+            logging.info("Download completed for blob: %s", blob_path.split("/")[-1])
+        logging.info("All data download complete")
 
 
-async def population_sync(country_code=None, year=DATA_YEAR, force_reprocessing=False, download_path=None):
+
+async def population_sync(country_code=None, year=DATA_YEAR, force_reprocessing=False, download_path=None, all_data=False):
     """
     Download all available data for a given country and year.
     Args:
@@ -329,6 +363,7 @@ async def population_sync(country_code=None, year=DATA_YEAR, force_reprocessing=
         country_code: (str) The country code for which to download data
         year: (Not implemented) The year for which to download data
         download_path: (Path) The local path to download the COG files to. It will upload to Azure if not provided.
+        all_data: (bool) Download all available data for all countries
 
     Returns: None
 
@@ -361,11 +396,9 @@ async def population_sync(country_code=None, year=DATA_YEAR, force_reprocessing=
             logging.info("Data download complete for country: %s", country_code)
             logging.info("Starting aggregate processing for country: %s", country_code)
 
-            if await check_aggregates_exist(container_client=container_client, country_code=country_code):
-                logging.info("Aggregate files already exist for country: %s", country_code)
-            else:
-                await process_aggregates(country_code=country_code, download_path=download_path,
-                                         force_reprocessing=force_reprocessing)
+            await process_aggregates(country_code=country_code, download_path=download_path,
+                                     force_reprocessing=force_reprocessing)
+
     logging.info("All data download and processing complete for country: %s", country_code)
 
 

--- a/cbsurge/exposure/population/worldpop.py
+++ b/cbsurge/exposure/population/worldpop.py
@@ -273,8 +273,9 @@ async def get_links_from_table(data_id=None):
 
 async def run_download(country_code=None, year=DATA_YEAR, download_path=None, sex=None, age_group=None, non_aggregates=False):
     """
-    Args:
+    Download population data (Cloud Optimised GeoTiff format) from UNDP Azure Blob Storage.
 
+    Args:
         country_code: (Required) The country code of the country intended to be downloaded
         year: (Not implemented) The year to download the data for
         download_path: (Required) local download path
@@ -318,6 +319,8 @@ async def run_download(country_code=None, year=DATA_YEAR, download_path=None, se
                 return [b.name async for b in
                         c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/aggregate")]
         else:
+            assert age_group!='total', "age-group=total is not supported for non aggregated data mode."
+
             if sex and age_group:
                 return [b.name async for b in c_client.list_blobs(name_starts_with=f"{AZ_ROOT_FILE_PATH}/{year}/{country_code}/{sex}/{age_group}")]
             elif sex:

--- a/tests/cbsurge/test_cli.py
+++ b/tests/cbsurge/test_cli.py
@@ -35,7 +35,7 @@ from cbsurge.cli import cli
         # test for rapida population --help
         (
             ["population", "--help"],
-            ["download", "run-aggregate", "sync"]
+            ["download", "aggregate", "sync"]
         ),
         # test for rapida population download --help
         (
@@ -44,8 +44,8 @@ from cbsurge.cli import cli
         ),
         # test for rapida population run-aggregate --help
         (
-            ["population", "run-aggregate", "--help"],
-            ["population run-aggregate"]
+            ["population", "aggregate", "--help"],
+            ["population aggregate"]
         ),
         # test for rapida population sync --help
         (


### PR DESCRIPTION
The following PR implements download from azure function and implements the CLI to download both aggregate and non-aggregate files from azure storage.

Usage:
` rapida population download --country BHS --download-path data/BHS/cogs --non-aggregates`
this will download all the non-aggregate files to the data/BHS/cogs folder.

` rapida population download --country BHS --download-path data/BHS/cogs/male --sex male --non-aggregates`
this will download all the non-aggregate files that are within the `male` folder for the country `BHS` to data/BHS/cogs/male folder