### PR TITLE
fix: add ComponentBase abstract class

### DIFF
--- a/cbsurge/component_base.py
+++ b/cbsurge/component_base.py
@@ -1,0 +1,49 @@
+from abc import ABCMeta, abstractmethod
+from typing import List
+
+class ComponentBase(metaclass=ABCMeta):
+    """
+    A base class for a component.
+    Each component class should have the following methods to be implemented:
+
+    - download: Download files for a component
+    - assess: A command to do all processing for a component including downloading component data, merging and making stats for a given admin data.
+    """
+
+    @abstractmethod
+    def download(self,
+                 bbox: List[float],
+                 output_folder: str,
+                 variables: List[str] = None
+                 )->List[str]:
+        """
+        Download files for a component
+
+        Args:
+            bbox: The bounding box for an interested area (the list of float values: minx, miny, maxx, maxy)
+            output_folder: output folder to store downloaded files
+            variables: Optional. The list of names of a variable to download. If skipped, all variables are downloaded.
+        Returns:
+            the list of downloaded file paths
+        """
+        pass
+
+    @abstractmethod
+    def assess(self,
+               admin_file: str,
+               output_folder: str,
+               mask_file: str = None,
+               variables: List[str] = None
+               )->str:
+        """
+        Do all processing for a component including downloading component data, merging and making stats for a given admin data.
+
+        Args:
+            admin_file: admin vector file path. Interested area either BBOX or country ISO3 codes are computed from a given admin file
+            output_folder: output folder to store all intermediary files and output files
+            mask_file: optional. raster mask file path. If provided, mask all component variables to compute affected variables.
+            variables: optional. The list of names of a variable to process. If skipped, all variables are processed.
+        Returns:
+            A file path of output file
+        """
+        pass


### PR DESCRIPTION
my idea is that it can be better to have an abstract class to define all same interface for each component (population, building, etc)

This is my proposed interface of abstract class