### PR TITLE
feat: added a function to compute population coefficient between target year and latest available year from world bank

### DIFF
--- a/cbsurge/exposure/population/pop_coefficient.py
+++ b/cbsurge/exposure/population/pop_coefficient.py
@@ -1,0 +1,70 @@
+import requests
+import datetime
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_pop_coefficient(target_year: int, country_code: str) -> list[int | float]:
+    """
+    Fetches population data from remote sources (world bank or UNSD) and calculates the population growth coefficient.
+
+    Compare the latest year available in both sources, and will pick the latest one to compute.
+
+    Currently, UNSD source is not supported. It returns always data from world bank.
+
+    Parameters:
+        target_year (int): The base year for comparison.
+        country_code (str): The ISO3 country code.
+
+    Returns:
+        list[int, float]: A list containing the latest available year and the calculated coefficient.
+    """
+    latest_year, coefficient = get_pop_coefficient_world_bank(target_year, country_code)
+    return [latest_year, coefficient]
+
+
+def get_pop_coefficient_world_bank(target_year: int, country_code: str) -> list[int | float]:
+    """
+    Fetches population data from the World Bank API and calculates the population growth coefficient.
+
+    Parameters:
+        target_year (int): The base year for comparison.
+        country_code (str): The ISO3 country code.
+
+    Returns:
+        list[int, float]: A list containing the latest available year and the calculated coefficient.
+    """
+
+    current_year = datetime.datetime.now().year
+    url = f"https://api.worldbank.org/v2/country/{country_code}/indicator/SP.POP.TOTL?format=json&date={target_year}:{current_year}"
+
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to fetch data: {response.status_code}")
+
+    data = response.json()
+    if len(data) < 2 or not isinstance(data[1], list):
+        raise RuntimeError("Invalid response format or no population data available.")
+
+    pop_data = {int(entry["date"]): entry["value"] for entry in data[1] if entry["value"] is not None}
+
+    if target_year not in pop_data:
+        raise RuntimeError(f"No population data available for {target_year}.")
+
+    latest_year = max(pop_data.keys())
+
+    if target_year > latest_year:
+        raise RuntimeError(f"{target_year} must be earlier than the latest year {latest_year}.")
+
+    latest_population = pop_data[latest_year]
+    target_population = pop_data[target_year]
+
+    coefficient = latest_population / target_population
+    return [latest_year, coefficient]
+
+if __name__ == '__main__':
+    latest_year, value = get_pop_coefficient(2020, "KEN")
+
+    print(latest_year, value )

--- a/tests/cbsurge/exposure/population/test_pop_coefficient.py
+++ b/tests/cbsurge/exposure/population/test_pop_coefficient.py
@@ -1,0 +1,128 @@
+import pytest
+from unittest.mock import patch
+from cbsurge.exposure.population.pop_coefficient import get_pop_coefficient_world_bank
+
+
+def mock_world_bank_api(*args, **kwargs):
+    class MockResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return [
+              {
+                "page": 1,
+                "pages": 1,
+                "per_page": 50,
+                "total": 4,
+                "sourceid": "2",
+                "lastupdated": "2025-01-28"
+              },
+              [
+                {
+                  "indicator": {
+                    "id": "SP.POP.TOTL",
+                    "value": "Population, total"
+                  },
+                  "country": {
+                    "id": "KE",
+                    "value": "Kenya"
+                  },
+                  "countryiso3code": "KEN",
+                  "date": "2023",
+                  "value": 55339003,
+                  "unit": "",
+                  "obs_status": "",
+                  "decimal": 0
+                },
+                {
+                  "indicator": {
+                    "id": "SP.POP.TOTL",
+                    "value": "Population, total"
+                  },
+                  "country": {
+                    "id": "KE",
+                    "value": "Kenya"
+                  },
+                  "countryiso3code": "KEN",
+                  "date": "2022",
+                  "value": 54252461,
+                  "unit": "",
+                  "obs_status": "",
+                  "decimal": 0
+                },
+                {
+                  "indicator": {
+                    "id": "SP.POP.TOTL",
+                    "value": "Population, total"
+                  },
+                  "country": {
+                    "id": "KE",
+                    "value": "Kenya"
+                  },
+                  "countryiso3code": "KEN",
+                  "date": "2021",
+                  "value": 53219166,
+                  "unit": "",
+                  "obs_status": "",
+                  "decimal": 0
+                },
+                {
+                  "indicator": {
+                    "id": "SP.POP.TOTL",
+                    "value": "Population, total"
+                  },
+                  "country": {
+                    "id": "KE",
+                    "value": "Kenya"
+                  },
+                  "countryiso3code": "KEN",
+                  "date": "2020",
+                  "value": 52217334,
+                  "unit": "",
+                  "obs_status": "",
+                  "decimal": 0
+                }
+              ]
+            ]
+
+
+    return MockResponse()
+
+
+def mock_world_bank_api_no_data(*args, **kwargs):
+    class MockResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return [{"page": 1, "pages": 1, "per_page": 50, "total": 0}, []]
+
+    return MockResponse()
+
+
+@patch('requests.get', side_effect=mock_world_bank_api)
+def test_get_pop_coefficient_world_bank(mock_get):
+    target_year = 2020
+    country_code = "KEN"
+    latest_year, coefficient = get_pop_coefficient_world_bank(target_year, country_code)
+
+    assert latest_year == 2023, "Latest year should be 2023"
+    assert coefficient == 55339003 / 52217334, "Coefficient calculation is incorrect"
+
+
+@patch('requests.get', side_effect=mock_world_bank_api)
+def test_get_pop_coefficient_world_bank_incorrect_target_year(mock_get):
+    target_year = 2024
+    country_code = "KEN"
+    with pytest.raises(RuntimeError, match="No population data available for 2024."):
+        get_pop_coefficient_world_bank(target_year, country_code)
+
+
+@patch('requests.get', side_effect=mock_world_bank_api_no_data)
+def test_get_pop_coefficient_world_bank_no_data(mock_get):
+    target_year = 2020
+    country_code = "KENN"
+    with pytest.raises(RuntimeError, match="No population data available."):
+        get_pop_coefficient_world_bank(target_year, country_code)
+


### PR DESCRIPTION
fixes #146 

added the below function to compute coefficient.

```python
def get_pop_coefficient_world_bank(target_year: int, country_code: str) -> list[int | float]:
    """
    Fetches population data from the World Bank API and calculates the population growth coefficient.
    Parameters:
        target_year (int): The base year for comparison.
        country_code (str): The ISO3 country code.
    Returns:
        list[int, float]: A list containing the latest available year and the calculated coefficient.
    """
```

this is called at parent function of `get_pop_coefficient` and will compare both result of world bank and UNSD to get latest one. currently UNSD is not supported.

Also, added some simple test cases by mocking world bank api.