### PR TITLE
fix: when PRODUCTION env is passed, install package without -e in Dockerfile for production.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,9 @@
 ./.github/
 ./.venv
 ./venv
+dist/
+data/
+*egg-info/
 .gitignore
 docker-compose.yaml
 Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         file: Dockerfile
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          PRODUCTION=true
 
   deploy-github:
     name: Build and deploy to GitHub container registry
@@ -135,3 +137,5 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PRODUCTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/osgeo/gdal:ubuntu-full-3.10.0
 
 ARG GROUP_NAME="cbsurge"
 ARG DATA_DIR='/data'
+ARG PRODUCTION
 
 ENV GROUP_NAME $GROUP_NAME
 ENV DATA_DIR $DATA_DIR
@@ -35,8 +36,12 @@ ENV VIRTUAL_ENV=/app/.venv
 # copy rest of files to the image.
 COPY . .
 
-# install rapida package and dependencies
-RUN pipenv run pip install -e .
+# Conditional installation based on PRODUCTION variable
+RUN if [ -z "$PRODUCTION" ]; then \
+        pipenv run pip install -e . ; \
+    else \
+        pipenv run pip install . ; \
+    fi
 
 # Create a group and set permissions for /app
 RUN groupadd ${GROUP_NAME} && \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 	@echo "------------------------------------------------------------------"
 	@echo "Building Docker image"
 	@echo "------------------------------------------------------------------"
-	docker compose -f docker-compose.yaml build
+	docker compose -f docker-compose.yaml build --build-arg PRODUCTION=$(PRODUCTION)
 
 up:
 	@echo

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ before running the above command, please use `devcontainer` or `make shell` to e
 make build
 ```
 
+If you would like to build image for production, execute the below command
+
+```shell
+PRODUCTION=true make build
+```
+
 - launch docker container
 
 ```shell


### PR DESCRIPTION
previously, always installed package by `pip install -e .`. Now use `pip install .` to install package for production.

build for production locally is like the below command.

```shell
PRODUCTION=true make build
```