### PR TITLE
feat: remove layer_name argument and implement code to manually remove outout file where it exists

### DIFF
--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -42,6 +42,8 @@ def admin():
 
 
 @admin.command(no_args_is_help=True)
+
+
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
 @click.option('-l','--admin_level',
@@ -68,13 +70,7 @@ def admin():
     help="Precision level for H3 indexing (default is 7)."
 )
 
-@click.option(
-    '--dst_path',
-    type=click.Path(),
-    default=None,
-    required=True,
-    help="The absolute path to an OGR dataset."
-)
+@click.argument('destination_path', type=click.Path())
 
 @click.option('--debug',
 
@@ -105,7 +101,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 
     To save the result as a file, for instance, the following command can be executed to extract admin 0 data for Rwanda and Burundi as GeoJSON file:
 
-    rapida admin osm -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 > osm.geojson
+    rapida admin osm -b "27.767944,-5.063586,31.734009,-0.417477" -l 0 osm.geojson
     """
     logger = logging.getLogger('rapida')
     if debug:
@@ -120,6 +116,9 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 
 
 @admin.command(no_args_is_help=True)
+
+
+
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
 @click.option('-l','--admin_level',
@@ -142,13 +141,9 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     help="Precision level for H3 indexing (default is 7)."
 )
 
-@click.option(
-    '--dst_path',
-    type=click.Path(),
-    default=None,
-    required=True,
-    help="The absolute path to an OGR dataset."
-)
+@click.argument('destination_path', type=click.Path())
+
+
 
 @click.option('--debug',
 
@@ -176,7 +171,7 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=Non
     To save the result as a file, for instance, the following command can be executed to extract admin 0 data for Rwanda and Burundi as GeoJSON file:
 
 
-    rapida admin ocha -b 33.681335,-0.131836,35.966492,1.158979 -l 2 --clip --dst_path /data/admocha.fgb --layer-name abc
+    rapida admin ocha -b 33.681335,-0.131836,35.966492,1.158979 -l 2 --clip /data/admocha.fgb --layer-name abc
     """
 
     logger = logging.getLogger('rapida')

--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -80,7 +80,7 @@ def admin():
 )
 
 
-def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7, dst_path=None, debug=False,):
+def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7, destination_path=None, debug=False,):
     """
     Fetch admin boundaries from OSM
 
@@ -111,7 +111,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     if not geojson:
         logger.error('Could not extract admin boundaries from OSM for the provided bbox')
         return
-    save(geojson_dict=geojson, dst_path=dst_path, layer_name=f'admin{admin_level}')
+    save(geojson_dict=geojson, dst_path=destination_path, layer_name=f'admin{admin_level}')
 
 
 
@@ -153,7 +153,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 )
 
 
-def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=None, debug=False ):
+def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, destination_path=None, debug=False ):
     """
     Fetch admin boundaries from OCHA COD
 
@@ -181,5 +181,5 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=Non
     if not geojson:
         logger.error('Could not extract admin boundaries from OCHA for the provided bbox')
         return
-    save(geojson_dict=geojson, dst_path=dst_path, layer_name=f'admin{admin_level}')
+    save(geojson_dict=geojson, dst_path=destination_path, layer_name=f'admin{admin_level}')
 

--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -43,6 +43,7 @@ def admin():
 
 @admin.command(no_args_is_help=True)
 
+@click.argument('destination_path', type=click.Path())
 
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
@@ -70,7 +71,7 @@ def admin():
     help="Precision level for H3 indexing (default is 7)."
 )
 
-@click.argument('destination_path', type=click.Path())
+
 
 @click.option('--debug',
 
@@ -117,7 +118,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 
 @admin.command(no_args_is_help=True)
 
-
+@click.argument('destination_path', type=click.Path())
 
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
@@ -141,7 +142,6 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     help="Precision level for H3 indexing (default is 7)."
 )
 
-@click.argument('destination_path', type=click.Path())
 
 
 

--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -1,5 +1,7 @@
 
 import logging
+import os
+
 from cbsurge.admin.osm import fetch_admin as fetch_osm_admin, ADMIN_LEVELS
 from cbsurge.admin.ocha import fetch_admin as fetch_ocha_admin
 from cbsurge.util import BboxParamType
@@ -18,6 +20,10 @@ def save(geojson_dict=None, dst_path=None, layer_name=None):
     :param layer_name: str, the layer name
     :return:
     """
+    # if there is a file remove it first to avoid raising a gdal error in cases where the file cannot be overwritten
+    if dst_path and os.path.exists(dst_path):
+        os.remove(dst_path)
+
     if dst_path is not None:
         with gdal.OpenEx(json.dumps(geojson_dict, indent=2)) as src:
             src_layer_name = src.GetLayer(0).GetName()
@@ -69,13 +75,6 @@ def admin():
     required=True,
     help="The absolute path to an OGR dataset."
 )
-@click.option(
-    '--layer-name',
-    type=str,
-    default=None,
-    required=True,
-    help="The name of the layer."
-)
 
 @click.option('--debug',
 
@@ -85,7 +84,7 @@ def admin():
 )
 
 
-def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7,dst_path=None, layer_name=None, debug=False,):
+def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7, dst_path=None, debug=False,):
     """
     Fetch admin boundaries from OSM
 
@@ -116,7 +115,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     if not geojson:
         logger.error('Could not extract admin boundaries from OSM for the provided bbox')
         return
-    save(geojson_dict=geojson, dst_path=dst_path, layer_name=layer_name)
+    save(geojson_dict=geojson, dst_path=dst_path, layer_name=f'admin{admin_level}')
 
 
 
@@ -150,13 +149,6 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     required=True,
     help="The absolute path to an OGR dataset."
 )
-@click.option(
-    '--layer-name',
-    type=str,
-    default=None,
-    required=True,
-    help="The name of the layer."
-)
 
 @click.option('--debug',
 
@@ -166,7 +158,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 )
 
 
-def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=None, layer_name=None, debug=False ):
+def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=None, debug=False ):
     """
     Fetch admin boundaries from OCHA COD
 
@@ -194,5 +186,5 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, dst_path=Non
     if not geojson:
         logger.error('Could not extract admin boundaries from OCHA for the provided bbox')
         return
-    save(geojson_dict=geojson, dst_path=dst_path, layer_name=layer_name)
+    save(geojson_dict=geojson, dst_path=dst_path, layer_name=f'admin{admin_level}')
 


### PR DESCRIPTION
in this PR:
1. [x] Removed `layer_name` from admin commands and set default to `admin{level}`
2. [x] manually remove file to avoid raising gdal errors where overwritting fails
3. [x] Changed `dst_path` argument to `destination_path` and made it used as an argument rather than option

Now complete admin command would be something like this:
`rapida admin ocha --bbox=33.681335,-0.131836,35.966492,1.158979 --admin_level=2 --clip data/admin2_ocha_cli.geojson`

Fixes #183 