### PR TITLE
fix: add mapclassify for leafmap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ jupyter = [
     "jupyterlab_widgets",
     "ipywidgets",
     "leafmap",
+    "mapclassify"
 ]
 
 [project.scripts]


### PR DESCRIPTION
`mapclassify` is required to use choropleth map in leafmap