### PR TITLE
fix: add error handling properly to allow rapida init to conitnue initialization without authentication

### DIFF
--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -2,24 +2,25 @@ import logging
 import click
 import os
 import shutil
-
-from requests import session
-
 from cbsurge.session import Session
 from cbsurge.components.population.variables import generate_variables as gen_pop_vars
-
+from cbsurge.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
 
 
 def setup_prompt(session: Session):
-    credential, token = session.authenticate()
-    logger.debug(token)
-    if token is None:
-        click.prompt("Authentication failed.Please `az login` to authenticate first.")
-        return
+    auth = session.authenticate()
+    if auth is None:
+        if click.confirm("Authentication failed. Do you want to continue initializing the tool? Yes/Enter to continue, No to cancel.", default=True):
+            click.echo("Initialization will continue without authentication. Please authenticate later.")
+        else:
+            click.echo("rapida init was cancelled. Please authenticate later.")
+            return
+    else:
+        click.echo("Authentication successful.")
 
-    click.echo("Authentication successful. We need more information to setup from you.")
+    click.echo("We need more information to setup from you.")
 
     # project root data folder
     root_data_folder = None
@@ -91,6 +92,7 @@ def setup_prompt(session: Session):
               )
 def init(debug=False):
     """ Initialize rapida tool"""
+    setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
 
     click.echo("Welcome to rapida CLI tool!")
     with Session() as session:

--- a/cbsurge/session.py
+++ b/cbsurge/session.py
@@ -227,7 +227,6 @@ class Session(object):
             return [credential, token]
         except ClientAuthenticationError as err:
             logger.error("authentication failed.")
-            logger.error(err)
             return None
 
 


### PR DESCRIPTION
fixes #226 

- allow users to continue doing initialization without azure authentication.
- call `setup_logger` to output logs properly

prompt is now like below if authentication failed.

- continue proceeding
```shell
rapida init
Welcome to rapida CLI tool!
Your setup has already been done. Would you like to do setup again? [y/N]: y
[02/20/25 05:57:26] WARNING  InteractiveBrowserCredential.get_token failed: Failed to open a browser                                                        interactive.py:228
                    WARNING  DefaultAzureCredential failed to retrieve a token from the included credentials.                                                   chained.py:152
                             Attempted credentials:                                                                                                                           
                                     EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.                 
                             Visit https://aka.ms/azsdk/python/identity/environmentcredential/troubleshoot to troubleshoot this issue.                                        
                                     ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint.                     
                                     SharedTokenCacheCredential: SharedTokenCacheCredential authentication unavailable. No accounts were found in the cache.                  
                                     AzureCliCredential: Please run 'az login' to set up an account                                                                           
                                     AzurePowerShellCredential: PowerShell is not installed                                                                                   
                                     AzureDeveloperCliCredential: Azure Developer CLI could not be found. Please visit https://aka.ms/azure-dev for                           
                             installation instructions and then,once installed, authenticate to your Azure account using 'azd auth login'.                                    
                                     InteractiveBrowserCredential: Failed to open a browser                                                                                   
                             To mitigate this issue, please refer to the troubleshooting guidelines here at                                                                   
                             https://aka.ms/azsdk/python/identity/defaultazurecredential/troubleshoot.                                                                        
                    ERROR    authentication failed.                                                                                                             session.py:229
Authentication failed. Do you want to continue initializing the tool? Yes/Enter to continue, No to cancel. [Y/n]: y
Initialization will continue without authentication. Please authenticate later.
We need more information to setup from you.
```

- cancel proceeding

```
rapida init
Welcome to rapida CLI tool!
Your setup has already been done. Would you like to do setup again? [y/N]: y
[02/20/25 05:58:22] WARNING  InteractiveBrowserCredential.get_token failed: Failed to open a browser                                                        interactive.py:228
                    WARNING  DefaultAzureCredential failed to retrieve a token from the included credentials.                                                   chained.py:152
                             Attempted credentials:                                                                                                                           
                                     EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.                 
                             Visit https://aka.ms/azsdk/python/identity/environmentcredential/troubleshoot to troubleshoot this issue.                                        
                                     ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint.                     
                                     SharedTokenCacheCredential: SharedTokenCacheCredential authentication unavailable. No accounts were found in the cache.                  
                                     AzureCliCredential: Please run 'az login' to set up an account                                                                           
                                     AzurePowerShellCredential: PowerShell is not installed                                                                                   
                                     AzureDeveloperCliCredential: Azure Developer CLI could not be found. Please visit https://aka.ms/azure-dev for                           
                             installation instructions and then,once installed, authenticate to your Azure account using 'azd auth login'.                                    
                                     InteractiveBrowserCredential: Failed to open a browser                                                                                   
                             To mitigate this issue, please refer to the troubleshooting guidelines here at                                                                   
                             https://aka.ms/azsdk/python/identity/defaultazurecredential/troubleshoot.                                                                        
                    ERROR    authentication failed.                                                                                                             session.py:229
Authentication failed. Do you want to continue initializing the tool? Yes/Enter to continue, No to cancel. [Y/n]: n
rapida init was cancelled. Please authenticate later.
```
