### PR TITLE
fix: electricity register variable

### DIFF
--- a/cbsurge/assess.py
+++ b/cbsurge/assess.py
@@ -136,7 +136,13 @@ def assess(ctx, components=None,  variables=None, year=None, force_compute=False
                             #click.echo(assess.get_help(ctx))
                             progress.remove_task(components_task)
                             sys.exit(1)
-                        fqcn = f'{__package__}.components.{component_name}.{component_name.capitalize()}Component'
+
+                        component_parts = component_name.split('.')
+                        class_name = f"{component_name.capitalize()}Component"
+                        if len(component_parts) > 1:
+                            class_name = f"{component_parts[-1].capitalize()}Component"
+
+                        fqcn = f'{__package__}.components.{component_name}.{class_name}'
                         cls = import_class(fqcn=fqcn)
                         component = cls()
                         component(progress=progress, variables=variables, target_year=year, force_compute=force_compute)

--- a/cbsurge/components/builtenv/electricity/__init__.py
+++ b/cbsurge/components/builtenv/electricity/__init__.py
@@ -17,7 +17,7 @@ from cbsurge.core.component import Component
 
 logger = logging.getLogger(__name__)
 
-class ElectricityGrid(Component, ABC):
+class ElectricityComponent(Component, ABC):
 
     dataset_url = 'https://geohub.data.undp.org/api/datasets/310aadaa61ea23811e6ecd75905aaf29'
 
@@ -51,7 +51,7 @@ class ElectricityVariable(Variable, ABC):
         print(project.geopackage_file_name)
 
     def download(self, **kwargs):
-        grid_component = ElectricityGrid()
+        grid_component = ElectricityComponent()
         url = grid_component.get_url
         self.download_geodata_by_admin(dataset_url=url)
         data = http_get_json(url)

--- a/cbsurge/components/builtenv/electricity/variables.py
+++ b/cbsurge/components/builtenv/electricity/variables.py
@@ -1,0 +1,30 @@
+import json
+from collections import OrderedDict
+import logging
+
+from cbsurge.util.setup_logger import setup_logger
+
+logger = logging.getLogger(__name__)
+
+def generate_variables():
+    """
+    Generate electricity variables dict
+    :return:
+    """
+
+    variables = OrderedDict()
+
+    #dependencies
+    variables['electricity_grid'] = dict(
+        title='Total length of electricity grid',
+        source='geohub:310aadaa61ea23811e6ecd75905aaf29',
+        operator="sum"
+    )
+    return variables
+
+
+if __name__ == '__main__':
+    logger = setup_logger(name='rapida', level=logging.INFO)
+
+    variables = generate_variables()
+    print(json.dumps(variables, indent=2))

--- a/cbsurge/components/builtenv/electricity/variables.py
+++ b/cbsurge/components/builtenv/electricity/variables.py
@@ -17,7 +17,7 @@ def generate_variables():
     #dependencies
     variables['electricity_grid'] = dict(
         title='Total length of electricity grid',
-        source='geohub:310aadaa61ea23811e6ecd75905aaf29',
+        source='geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29',
         operator="sum"
     )
     return variables

--- a/cbsurge/components/builtenv/electricity/variables.py
+++ b/cbsurge/components/builtenv/electricity/variables.py
@@ -15,7 +15,7 @@ def generate_variables():
     variables = OrderedDict()
 
     #dependencies
-    variables['electricity_grid'] = dict(
+    variables['electricity_grid_length'] = dict(
         title='Total length of electricity grid',
         source='geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29',
         operator="sum"

--- a/cbsurge/core/variable.py
+++ b/cbsurge/core/variable.py
@@ -225,7 +225,8 @@ class Variable(BaseModel):
             :param kwargs:
             :return:
             """
-            logger.debug(f'Assessing variable {self.name} in {kwargs["country"]}')
+            country = kwargs.get("country")
+            logger.debug(f'Assessing variable {self.name}' + (f' in {country}' if country else ''))
 
             force_compute = kwargs.get('force_compute', False)
             if not self.dep_vars: #simple variable,

--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -78,7 +78,7 @@ def setup_prompt(session: Session):
     vars_dict = {
         "variables": {
             "population":  gen_pop_vars(),
-            "electricity": gen_electric_vars(),
+            "builtenv.electricity": gen_electric_vars(),
         }
     }
     session.config.update(vars_dict)

--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from cbsurge.session import Session
 from cbsurge.components.population.variables import generate_variables as gen_pop_vars
+from cbsurge.components.builtenv.electricity.variables import generate_variables as gen_electric_vars
 from cbsurge.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,8 @@ def setup_prompt(session: Session):
     session.save_config()
     vars_dict = {
         "variables": {
-            "population":  gen_pop_vars()
+            "population":  gen_pop_vars(),
+            "electricity": gen_electric_vars(),
         }
     }
     session.config.update(vars_dict)


### PR DESCRIPTION
the following variable definition is registered to config.json

```
        "builtenv.electricity": {
            "electricity_grid_length": {
                "title": "Total length of electricity grid",
                "source": "geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29",
                "operator": "sum"
            }
        }

```

electricity can be assessed like below command

```
 rapida assess -c builtenv.electricity -v electricity_grid_length
```