### PR TITLE
fix: add xarray and localtileserver for jupyter to allow using local tiff for leafmap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,9 @@ jupyter = [
     "jupyterlab_widgets",
     "ipywidgets",
     "leafmap",
-    "mapclassify"
+    "mapclassify",
+    "xarray",
+    "localtileserver"
 ]
 
 [project.scripts]


### PR DESCRIPTION
xarray and localtileserver are needed for leafmap to use local tiff in the server