### PR TITLE
Fix/issue 207

### DIFF
--- a/cbsurge/assess.py
+++ b/cbsurge/assess.py
@@ -68,14 +68,15 @@ def assess(ctx, components=None,  variables=None, year=None, force_compute=False
                 with Session() as session:
                     all_components = session.get_components()
                     components = components or all_components
-                    components_task = progress.add_task(
-                        description=f'[green]Assessing {"".join(components)} ', total=len(components))
+                    comp_word = 'components' if len(components)> 1 else 'component'
+                    # components_task = progress.add_task(
+                    #     description=f'[green]Assessing [red]{"".join(components)}[green] {comp_word}', total=len(components))
                     for component_name in components:
                         if not component_name in all_components:
                             msg = f'Component {component_name} is invalid. Valid options  are: "{",".join(all_components)}"'
                             logger.error(msg)
                             click.echo(assess.get_help(ctx))
-                            progress.remove_task(components_task)
+                            #progress.remove_task(components_task)
                             sys.exit(1)
 
                         component_parts = component_name.split('.')
@@ -87,9 +88,10 @@ def assess(ctx, components=None,  variables=None, year=None, force_compute=False
                         cls = import_class(fqcn=fqcn)
                         component = cls()
                         component(progress=progress, variables=variables, target_year=year, force_compute=force_compute)
-                        progress.update(components_task,description=f'Assessed {component_name}', advance=1)
 
-                    #progress.remove_task(components_task)
+                        #progress.update(components_task,  advance=1, )
+
+
         else:
             logger.info(f'"{current_folder}" is not a valid rapida project folder')
 

--- a/cbsurge/az/blobstorage.py
+++ b/cbsurge/az/blobstorage.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 import os
 import aiofiles
-from csv import excel
-from rich.progress import Progress, FileSizeColumn, BarColumn, TimeRemainingColumn
 
 from cbsurge.session import Session
 from cbsurge.util.chunker import chunker
@@ -17,20 +15,31 @@ logger = logging.getLogger(__name__)
 
 
 
-async def download(blob_client:BlobClient = None, dst_path:str=None, progress=None, task=None):
+async def download(blob_client:BlobClient = None, dst_path:str=None, progress=None, downloads_task=None):
 
     if not await blob_client.exists():
         raise ValueError(f"Blob {blob_client.blob_name} does not exist")
     try:
         logger.debug(f"Going to download {blob_client.blob_name} to {dst_path}")
         blob_props = await blob_client.get_blob_properties()
-        total_size = blob_props.size  # Total bytes to download
+        blob_size = blob_props.size  # Total bytes to download
         blob = await blob_client.download_blob()
+        task = None
+        name = os.path.split(blob_props.name)[-1]
+        if progress is not None:
+            task = progress.add_task(description='', total=blob_size)
         async with aiofiles.open(dst_path, "wb") as f:
             async for chunk in blob.chunks():
                 await f.write(chunk)
-        if progress and task:
-            progress.update(task, advance=1)
+                if progress is not None and task is not None:
+                    progress.update(task, advance=len(chunk))
+                if progress is not None and downloads_task is not None:
+                    progress.update(downloads_task, description=f'[blue]Downloading {name}',)
+            if progress is not None and task is not None:
+                progress.remove_task(task)
+
+        if progress is not None and downloads_task is not None:
+            progress.update(downloads_task, advance=1)
     except Exception as e:
         logger.error(f"Failed to download the blob from {blob_client.blob_name}: {e}")
         raise
@@ -40,7 +49,7 @@ async def download(blob_client:BlobClient = None, dst_path:str=None, progress=No
 
 
 
-async def download_blob(src_path: str = None, dst_path: str = None) -> str:
+async def download_blob(src_path: str = None, dst_path: str = None, progress=None) -> str:
     """
     Download a blob from Azure Blob Storage to a local storage.
 
@@ -65,7 +74,7 @@ async def download_blob(src_path: str = None, dst_path: str = None) -> str:
     async with Session() as session:
         async with session.get_blob_container_client(account_name=account_name,container_name=container_name) as cc:
             blob_client = cc.get_blob_client(blob=rel_src_blob_path)
-            return await download(blob_client=blob_client, dst_path=dst_path )
+            return await download(blob_client=blob_client, dst_path=dst_path, progress=progress )
 
 
 async def upload(src_path, dst_path, blob_client:BlobClient = None, blob_type:BlobType =  BlobType.BLOCKBLOB, overwrite=True):
@@ -152,7 +161,7 @@ async def download_blobs(src_blobs:Iterable[str] = None, dst_folder:str = None, 
         async with session.get_blob_container_client(account_name=account_name,container_name=container_name) as cc:
                 if progress:
                     download_task = progress.add_task(
-                        description=f'[blue]Going to download {len(src_blobs)} blobs', total=len(src_blobs))
+                        description=f'[blue]Preparing to download...', total=len(src_blobs))
 
                 for i, blobs in enumerate(chunker(src_blobs, size=max_at_once), start=1):
                     download_tasks = dict()
@@ -167,7 +176,7 @@ async def download_blobs(src_blobs:Iterable[str] = None, dst_folder:str = None, 
                             blob_client = cc.get_blob_client(blob=rel_src_blob_path)
                             dst_path = os.path.join(dst_folder, src_blob_name)
                             task = asyncio.create_task(
-                                download(blob_client=blob_client, dst_path=dst_path,progress=progress, task=download_task),
+                                download(blob_client=blob_client, dst_path=dst_path, progress=progress, downloads_task=download_task),
                                 name=src_blob_name
                             )
                             download_tasks[src_blob_name] = task

--- a/cbsurge/components/population/__init__.py
+++ b/cbsurge/components/population/__init__.py
@@ -5,15 +5,14 @@ from typing import List
 import logging
 import pycountry
 from pyogrio import write_dataframe
-from cbsurge import constants
+from cbsurge.constants import POLYGONS_LAYER_NAME,GTIFF_CREATION_OPTIONS
 from cbsurge.util import geo
-import cbsurge.constants
 from cbsurge.core.component import Component
 from cbsurge.project import Project
 from cbsurge.session import Session
 from cbsurge.core.variable import Variable
 from osgeo_utils.gdal_calc import Calc
-from osgeo import gdal, osr
+from osgeo import gdal
 import click
 from cbsurge.components.population.worldpop import population_sync, process_aggregates, run_download
 from cbsurge.stats.zst import sumup, zst
@@ -25,6 +24,9 @@ import re
 
 COUNTRY_CODES = set([c.alpha_3 for c in pycountry.countries])
 logger = logging.getLogger('rapida')
+
+
+
 gdal.UseExceptions()
 @click.group()
 def population():
@@ -141,7 +143,7 @@ class PopulationComponent(Component):
 
     def __call__(self, variables: List[str] = None, **kwargs) -> str:
 
-        logger.debug(f'Assessing component "{self.component_name}" ')
+
         if not variables:
             variables = self.variables
         else:
@@ -153,7 +155,7 @@ class PopulationComponent(Component):
 
         progress = kwargs.get('progress', None)
         project = Project(path=os.getcwd())
-
+        logger.info(f'Assessing component "{self.component_name}" over {", ".join(project.countries)}')
         with Session() as ses:
             variables_data = ses.get_component(self.component_name)
             nvars = len(variables)
@@ -216,50 +218,63 @@ class PopulationVariable(Variable):
     def compute(self, **kwargs):
 
         logger.debug(f'Computing {self.name}')
+        var_path = os.path.join(self._source_folder_, f'{self.name}.tif')
+        project = Project(os.getcwd())
+        sources = list()
+        for country in project.countries:
+            if not self.dep_vars:
+                # interpolate templates
+                source_blobs = list()
+                for source_template in self.sources:
+                    source_file_path = self.interpolate_template(template=source_template, country=country, **kwargs)
+                    source_blobs.append(source_file_path)
+                if not os.path.exists(self._source_folder_):
+                    os.makedirs(self._source_folder_)
+                downloaded_files = asyncio.run(
+                    blobstorage.download_blobs(src_blobs=source_blobs, dst_folder=self._source_folder_,
+                                               progress=kwargs.get('progress', None))
+                )
+                assert len(self.sources) == len(downloaded_files), f'Not all sources were downloaded for {self.name} variable'
+                src_path = self.interpolate_template(template=self.source, country=country, **kwargs)
+                _, file_name = os.path.split(src_path)
+                local_path = os.path.join(self._source_folder_, file_name)
+                logger.info(f'Going to compute {self.name} from {len(downloaded_files)} source files in {country}')
+                computed_file = sumup(src_rasters=downloaded_files,dst_raster=local_path, overwrite=True)
+                assert os.path.exists(computed_file), f'The computed file: {computed_file} does not exists'
+                sources.append(computed_file)
 
-        if not self.dep_vars:
-            logger.debug(f'Going to download {self.name} from source files')
+            else:
+                for country in project.countries:
+                    logger.info(f'Going to compute {self.name}={self.sources}')
+                    src_path = self.interpolate_template(template=self.source, country=country, **kwargs)
+                    _, file_name = os.path.split(src_path)
+                    computed_file = os.path.join(self._source_folder_, file_name)
+                    if not os.path.exists(self._source_folder_):
+                        os.makedirs(self._source_folder_)
+                    depvar_sources = self.resolve(**kwargs)
 
-            # interpolate templates
-            source_blobs = list()
-            for source_template in self.sources:
-                source_file_path = self.interpolate_template(template=source_template, **kwargs)
-                source_blobs.append(source_file_path)
-            if not os.path.exists(self._source_folder_):
-                os.makedirs(self._source_folder_)
-            downloaded_files = asyncio.run(
-                blobstorage.download_blobs(src_blobs=source_blobs, dst_folder=self._source_folder_,
-                                           progress=kwargs.get('progress', None))
-            )
-            assert len(self.sources) == len(downloaded_files), f'Not all sources were downloaded for {self.name} variable'
-            src_path = self.interpolate_template(template=self.source, **kwargs)
-            _, file_name = os.path.split(src_path)
-            local_path = os.path.join(self._source_folder_, file_name)
-            logger.info(f'Going to compute {self.name} from {len(downloaded_files)} source files')
-            computed_file = sumup(src_rasters=downloaded_files,dst_raster=local_path, overwrite=True)
-            assert os.path.exists(computed_file), f'The computed file: {computed_file} does not exists'
-            self.local_path = computed_file
-        else:
-            logger.info(f'Going to compute {self.name}={self.sources}')
-            src_path = self.interpolate_template(template=self.source, **kwargs)
-            _, file_name = os.path.split(src_path)
-            computed_file = os.path.join(self._source_folder_, file_name)
-            if not os.path.exists(self._source_folder_):
-                os.makedirs(self._source_folder_)
-            sources = self.resolve(**kwargs)
-            creation_options = cbsurge.constants.GTIFF_CREATION_OPTIONS
+                    ds = Calc(calc=self.sources, outfile=computed_file,  projectionCheck=True, format='GTiff',
+                              creation_options=GTIFF_CREATION_OPTIONS, quiet=False, overwrite=True,  **depvar_sources)
 
-            ds = Calc(calc=self.sources, outfile=computed_file,  projectionCheck=True, format='GTiff',
-                      creation_options=creation_options.split(' '), quiet=False, overwrite=True,  **sources)
-
-            assert os.path.exists(computed_file), f'The computed file: {computed_file} does not exists'
-            self.local_path = computed_file
-        self.import_raster()
+                    assert os.path.exists(computed_file), f'The computed file: {computed_file} does not exists'
+                    sources.append(computed_file)
+        vrt_options = gdal.BuildVRTOptions(
+            resolution='highest',
+            resampleAlg='nearest',
+            allowProjectionDifference=False,
+        )
+        vrt_path = var_path.replace('.tif', '.vrt')
+        vrtds = gdal.BuildVRT(destName=vrt_path, srcDSOrSrcDSTab=sources, options=vrt_options)
+        ds = gdal.Translate(destName=var_path, srcDS=vrtds)
+        ds = None
+        vrtds = None
+        imported_file_path = self.import_raster(source=var_path)
+        assert imported_file_path == var_path, f'var_path differs from {imported_file_path}'
+        self.local_path = var_path
         self._compute_affected_()
 
     def resolve(self,  **kwargs):
         with Session() as s:
-            # project = Project(path=os.getcwd())
             sources = dict()
             for var_name in self.dep_vars:
                 var_dict = s.get_variable(component=self.component, variable=var_name)
@@ -388,7 +403,7 @@ class PopulationVariable(Variable):
             dst=imported_local_path,
             target_srs=project.target_srs,
             crop_ds=project.geopackage_file_path,
-            crop_layer_name=constants.POLYGONS_LAYER_NAME,
+            crop_layer_name=POLYGONS_LAYER_NAME,
             **kwargs
         )
 
@@ -402,7 +417,7 @@ class PopulationVariable(Variable):
             project = Project(os.getcwd())
             affected_local_path = self.affected_path
             ds = Calc(calc='local_path*mask', outfile=affected_local_path, projectionCheck=True, format='GTiff',
-                      creation_options=constants.GTIFF_CREATION_OPTIONS, quiet=False, overwrite=True,
+                      creation_options=GTIFF_CREATION_OPTIONS, quiet=False, overwrite=True,
                       NoDataValue=None,
                       local_path=self.local_path, mask=project.raster_mask)
             ds = None

--- a/cbsurge/core/variable.py
+++ b/cbsurge/core/variable.py
@@ -199,25 +199,47 @@ class Variable(BaseModel):
         """
 
         force_compute = kwargs.get('force_compute', False)
+        progress = kwargs.get('progress', None)
+
+
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
+
         if not self.dep_vars: #simple variable,
             if not force_compute:
                 # logger.debug(f'Downloading {self.name} source')
                 self.download(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
             else:
                 # logger.debug(f'Computing {self.name} using gdal_calc from sources')
                 self.compute(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}',)
+
         else:
             if self.operator:
                 if not force_compute:
                     # logger.debug(f'Downloading {self.name} from  source')
                     self.download(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
                 else:
-                    # logger.debug(f'Computing {self.name}={self.sources} using GDAL')
+                    #logger.info(f'Computing {self.name}={self.sources} using GDAL')
                     self.compute(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
             else:
                 #logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
                 sources = self.resolve(**kwargs)
 
-        return self.evaluate(**kwargs)
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress._tasks[variable_task].total = 1
+            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+
+
+
 
 

--- a/cbsurge/util/silence_httpx_az.py
+++ b/cbsurge/util/silence_httpx_az.py
@@ -11,3 +11,5 @@ def silence_httpx_az():
     requests_logger.setLevel(logging.WARNING)
     msal_logger = logging.getLogger('msal')
     msal_logger.setLevel(logging.WARNING)
+    pyogrio_logger = logging.getLogger('pyogrio')
+    pyogrio_logger.setLevel(logging.WARNING)


### PR DESCRIPTION
Fix issues related to derived variables and multi-country project when force-compute is applied.

The force-compute flag in assess command  results in downloading the lowest level pop data and reconstructing the 
variables recursively one by one.

This has introduced complexity specially when executed on a multicountry project.

The solution in these kind of situations is to delegate and 
- [x] implement the multi-country code to the download and compute functions for simple computable variables 
- [x] merge individual countries into a VRT
- [x]  translate the VRT to TIF
- [x] import the tiff:
     - [x] crop by polygons
     - [x] reproject to target projection
     - [x] resample to match the mask resolution 
- [x] compute the affected version using the mask


The derived variables are just resolved recursively.

closes #207 

