### PR TITLE
move __call__/assess into every variable type from core

### DIFF
--- a/cbsurge/components/buildings/__init__.py
+++ b/cbsurge/components/buildings/__init__.py
@@ -148,6 +148,57 @@ class BuildingsComponent(Component):
 
 class BuildingsVariable(Variable):
 
+    def __call__(self, *args, **kwargs):
+        """
+                Assess a variable. Essentially this means a series of steps in a specific order:
+                    - download
+                    - preprocess
+                    - analysis/zonal stats
+
+                :param kwargs:
+                :return:
+                """
+
+        force_compute = kwargs.get('force_compute', False)
+        progress = kwargs.get('progress', None)
+
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
+
+        if not self.dep_vars:  # simple variable,
+            if not force_compute:
+                # logger.debug(f'Downloading {self.name} source')
+                self.download(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name} using gdal_calc from sources')
+                self.compute(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}', )
+
+        else:
+            if self.operator:
+                if not force_compute:
+                    # logger.debug(f'Downloading {self.name} from  source')
+                    self.download(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+                else:
+                    # logger.info(f'Computing {self.name}={self.sources} using GDAL')
+                    self.compute(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
+                sources = self.resolve(**kwargs)
+
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress._tasks[variable_task].total = 1
+            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+
     def download(self, progress=None, force_compute=None, **kwargs):
 
         logger.debug(f'Downloading {self.name}')

--- a/cbsurge/components/electricity/__init__.py
+++ b/cbsurge/components/electricity/__init__.py
@@ -86,6 +86,58 @@ class ElectricityComponent(Component, ABC):
 
 
 class ElectricityVariable(Variable):
+
+    def __call__(self, *args, **kwargs):
+        """
+                Assess a variable. Essentially this means a series of steps in a specific order:
+                    - download
+                    - preprocess
+                    - analysis/zonal stats
+
+                :param kwargs:
+                :return:
+                """
+
+        force_compute = kwargs.get('force_compute', False)
+        progress = kwargs.get('progress', None)
+
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
+
+        if not self.dep_vars:  # simple variable,
+            if not force_compute:
+                # logger.debug(f'Downloading {self.name} source')
+                self.download(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name} using gdal_calc from sources')
+                self.compute(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}', )
+
+        else:
+            if self.operator:
+                if not force_compute:
+                    # logger.debug(f'Downloading {self.name} from  source')
+                    self.download(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+                else:
+                    # logger.info(f'Computing {self.name}={self.sources} using GDAL')
+                    self.compute(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
+                sources = self.resolve(**kwargs)
+
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress._tasks[variable_task].total = 1
+            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/cbsurge/components/population/__init__.py
+++ b/cbsurge/components/population/__init__.py
@@ -184,6 +184,60 @@ class PopulationComponent(Component):
 
 class PopulationVariable(Variable):
 
+
+
+    def __call__(self, *args, **kwargs):
+        """
+                Assess a variable. Essentially this means a series of steps in a specific order:
+                    - download
+                    - preprocess
+                    - analysis/zonal stats
+
+                :param kwargs:
+                :return:
+                """
+
+        force_compute = kwargs.get('force_compute', False)
+        progress = kwargs.get('progress', None)
+
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
+
+        if not self.dep_vars:  # simple variable,
+            if not force_compute:
+                # logger.debug(f'Downloading {self.name} source')
+                self.download(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name} using gdal_calc from sources')
+                self.compute(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}', )
+
+        else:
+            if self.operator:
+                if not force_compute:
+                    # logger.debug(f'Downloading {self.name} from  source')
+                    self.download(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+                else:
+                    # logger.info(f'Computing {self.name}={self.sources} using GDAL')
+                    self.compute(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
+                sources = self.resolve(**kwargs)
+
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress._tasks[variable_task].total = 1
+            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+
+
     def compute(self, **kwargs):
 
 
@@ -429,3 +483,6 @@ class PopulationVariable(Variable):
 
     def alter(self, **kwargs):
         return f'vrt://{self.local_path}?{urlencode(kwargs)}'
+
+
+

--- a/cbsurge/components/rwi/__init__.py
+++ b/cbsurge/components/rwi/__init__.py
@@ -63,6 +63,58 @@ class RwiVariable(Variable):
         output_filename = f"{self.component}.tif"
         self.local_path = os.path.join(os.path.dirname(geopackage_path), output_filename)
 
+    def __call__(self, *args, **kwargs):
+        """
+                Assess a variable. Essentially this means a series of steps in a specific order:
+                    - download
+                    - preprocess
+                    - analysis/zonal stats
+
+                :param kwargs:
+                :return:
+                """
+
+        force_compute = kwargs.get('force_compute', False)
+        progress = kwargs.get('progress', None)
+
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
+
+        if not self.dep_vars:  # simple variable,
+            if not force_compute:
+                # logger.debug(f'Downloading {self.name} source')
+                self.download(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name} using gdal_calc from sources')
+                self.compute(**kwargs)
+                if progress is not None and variable_task is not None:
+                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}', )
+
+        else:
+            if self.operator:
+                if not force_compute:
+                    # logger.debug(f'Downloading {self.name} from  source')
+                    self.download(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
+                else:
+                    # logger.info(f'Computing {self.name}={self.sources} using GDAL')
+                    self.compute(**kwargs)
+                    if progress is not None and variable_task is not None:
+                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
+            else:
+                # logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
+                sources = self.resolve(**kwargs)
+
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress._tasks[variable_task].total = 1
+            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+
+
     def download(self, **kwargs):
         """
         Download RWI data source

--- a/cbsurge/core/variable.py
+++ b/cbsurge/core/variable.py
@@ -71,56 +71,7 @@ class Variable(BaseModel):
         pass
 
     def __call__(self,  **kwargs):
-        """
-        Assess a variable. Essentially this means a series of steps in a specific order:
-            - download
-            - preprocess
-            - analysis/zonal stats
-
-        :param kwargs:
-        :return:
-        """
-
-        force_compute = kwargs.get('force_compute', False)
-        progress = kwargs.get('progress', None)
-
-
-        if progress is not None:
-            variable_task = progress.add_task(
-                description=f'[blue]Assessing {self.component}->{self.name}', total=None)
-
-        if not self.dep_vars: #simple variable,
-            if not force_compute:
-                # logger.debug(f'Downloading {self.name} source')
-                self.download(**kwargs)
-                if progress is not None and variable_task is not None:
-                    progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
-            else:
-                # logger.debug(f'Computing {self.name} using gdal_calc from sources')
-                self.compute(**kwargs)
-                if progress is not None and variable_task is not None:
-                    progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}',)
-
-        else:
-            if self.operator:
-                if not force_compute:
-                    # logger.debug(f'Downloading {self.name} from  source')
-                    self.download(**kwargs)
-                    if progress is not None and variable_task is not None:
-                        progress.update(variable_task, description=f'[blue]Downloaded {self.component}->{self.name}')
-                else:
-                    #logger.info(f'Computing {self.name}={self.sources} using GDAL')
-                    self.compute(**kwargs)
-                    if progress is not None and variable_task is not None:
-                        progress.update(variable_task, description=f'[blue]Computed {self.component}->{self.name}')
-            else:
-                #logger.debug(f'Computing {self.name}={self.sources} using GeoPandas')
-                sources = self.resolve(**kwargs)
-
-        self.evaluate(**kwargs)
-        if progress is not None and variable_task is not None:
-            progress._tasks[variable_task].total = 1
-            progress.update(variable_task, description=f'[blue]Assessed {self.component}->{self.name}', advance=1)
+        pass
 
     def interpolate_template(self, template=None, **kwargs):
         """

--- a/cbsurge/core/variable.py
+++ b/cbsurge/core/variable.py
@@ -69,7 +69,7 @@ class Variable(BaseModel):
     @abstractmethod
     def resolve(self, **kwargs):
         pass
-
+    @abstractmethod
     def __call__(self,  **kwargs):
         pass
 


### PR DESCRIPTION
The __call__ methods was implemented one in the Variable superclass. However as @JinIgarashi pointed out it specific implementation details applicable to only population component (see force_compute) make it tricky to use this implementation in other components

As a result this PR removed the  implementation from core.variable into each component/variable type.

