### PR TITLE
feat: dynamically set components and variables for click.option's choices

### DIFF
--- a/cbsurge/util/download_geodata.py
+++ b/cbsurge/util/download_geodata.py
@@ -661,7 +661,7 @@ def download_raster(
                 dstSRS=polygons_crs.to_wkt(),
                 format="COG",
                 creationOptions=["COMPRESS=ZSTD", "PREDICTOR=2","BIGTIFF=IF_SAFER", "BLOCKSIZE=256"],
-                resampleAlg='nearest',
+                resampleAlg='average',
                 srcNodata=src_nodata,
                 callback=progress_callback
             )


### PR DESCRIPTION
closes #254

Now available components and variables are shown in help message

```shell
rapida assess --help
Usage: rapida assess [OPTIONS]

  Assess the effect of natural or social hazard

Options:
  -c, --components [buildings|rwi|electricity|population|roads|deprivation]
                                  One or more components to be assessed. Valid
                                  input example: -c buildings -c rwi
  -v, --variables [nbuildings|buildings_area|rwi_mean|rwi_min|rwi_max|electricity_grid_length|electricity_grid_density|female_total|child_total|male_active|female_active|child_dependency|female_child|dependency|elderly_dependency|male_elderly|male_total|female_elderly|total|male_child|elderly_total|active_total|roads_count|roads_length|depriv_min|depriv_max|depriv_mean]
                                  The variable/s to be assessed. Valid input
                                  example: -v nbuildings -v buildings_area
  -y, --year INTEGER              The year for which to compute population
                                  [default: 2025]
  -f, --force_compute             Force recomputation from sources that are
                                  files
  -d, --debug                     Turn on debug mode
  --help                          Show this message and exit.
```

if no config.json is found, the below warning message will be shown to initialize the tool first.

```shell
rapida assess
[03/17/25 07:43:50] WARNING  There are no available components. Please run `rapida init` to setup the tool first    
```