### PR TITLE
feat: added GDP component, and added license/attribution for each component variable

### DIFF
--- a/cbsurge/components/buildings/variables.py
+++ b/cbsurge/components/buildings/variables.py
@@ -3,7 +3,10 @@ GMOSM_BUILDINGS_ROOT = 'https://data.source.coop/vida/google-microsoft-osm-open-
 GMOSM_BUILDINGS_URL = f'/vsicurl/{GMOSM_BUILDINGS_ROOT}/country_iso={{country}}/{{country}}.fgb::{{country}}'
 
 def generate_variables():
+    license = "Open Data Commons Open Database License (ODbL)"
+    attribution = "Google, Microsoft, VIDA, Protomaps"
+
     variables = OrderedDict()
-    variables['nbuildings'] = dict(title='Number of buildings', source=GMOSM_BUILDINGS_URL,  operator='count', percentage=True)
-    variables['buildings_area'] = dict(title='Buildings surface area', source=GMOSM_BUILDINGS_URL,  operator='sum', percentage=True)
+    variables['nbuildings'] = dict(title='Number of buildings', source=GMOSM_BUILDINGS_URL,  operator='count', percentage=True, license=license, attribution=attribution)
+    variables['buildings_area'] = dict(title='Buildings surface area', source=GMOSM_BUILDINGS_URL,  operator='sum', percentage=True, license=license, attribution=attribution)
     return variables

--- a/cbsurge/components/deprivation/variables.py
+++ b/cbsurge/components/deprivation/variables.py
@@ -10,12 +10,18 @@ def generate_variables():
     :return RWI variables definition
     """
 
+    # https://www.earthdata.nasa.gov/data/catalog/sedac-ciesin-sedac-pmp-grdi-2010-2020-1.00
+    license = "Creative Commons Zero (CC0)"
+    attribution = "Center for International Earth Science Information Network - CIESIN - Columbia University"
+
     variables = OrderedDict()
     names = 'Average', 'Smallest', 'Largest'
     for i, operator in enumerate(['mean', 'min', 'max']):
         variables[f'depriv_{operator}'] = dict(
             title=f'{names[i]} value of relative deprivation index',
             source='geohub:/api/datasets/8b885646578937906c1d2759657f98e4',
-            operator=operator
+            operator=operator,
+            license=license,
+            attribution=attribution,
         )
     return variables

--- a/cbsurge/components/electricity/variables.py
+++ b/cbsurge/components/electricity/variables.py
@@ -12,6 +12,9 @@ def generate_variables():
 
     variables = OrderedDict()
 
+    license = "Creative Commons BY 4.0"
+    attribution = "World Bank Group, University of Oxford"
+
     for operator in ['sum', 'count', 'density']:
         name = operator
         if operator == 'sum':
@@ -21,6 +24,8 @@ def generate_variables():
             source='geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29',
             operator=operator,
             percentage=True if operator != 'density' else False,
+            license=license,
+            attribution=attribution,
         )
 
     return variables

--- a/cbsurge/components/gdp/__init__.py
+++ b/cbsurge/components/gdp/__init__.py
@@ -1,0 +1,341 @@
+import asyncio
+import os
+import re
+import logging
+import math
+import shutil
+from typing import List
+from rich.progress import Progress
+import geopandas as gpd
+from osgeo import gdal, ogr
+from osgeo_utils.gdal_calc import Calc
+from cbsurge import constants
+from cbsurge.constants import GTIFF_CREATION_OPTIONS
+from cbsurge.core.component import Component
+from cbsurge.core.variable import Variable
+from cbsurge.project import Project
+from cbsurge.session import Session
+from cbsurge.stats.zst import zst
+from cbsurge.util import geo
+from cbsurge.util.download_geodata import download_raster
+logger = logging.getLogger(__name__)
+
+
+class GdpComponent(Component):
+    """
+    Gridded GDP component
+
+    License: Creative Commons Attribution 4.0 International
+    Citation: Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios [Data set]. Zenodo. https://doi.org/10.5281/zenodo.7898409
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+    def __call__(self, variables: List[str] = None, target_year: int=None, **kwargs) -> str:
+        if not variables:
+            variables = self.variables
+        else:
+            for var_name in variables:
+                if not var_name in self.variables:
+                    logger.error(f'variable "{var_name}" is invalid. Valid options are "{", ".join(self.variables)}"')
+                    return
+
+        with Session() as ses:
+            variables_data = ses.get_component(self.component_name)
+
+            # delete stats layer if exist
+            project = Project(path=os.getcwd())
+            geopackage_path = project.geopackage_file_path
+            with ogr.Open(geopackage_path, 1) as ds:
+                dst_layer = f"stats.{self.component_name}"
+                layer_index = ds.GetLayerByName(dst_layer)
+                if layer_index is not None:
+                    ds.DeleteLayer(dst_layer)
+
+            for var_name in variables:
+                var_data = variables_data[var_name]
+                sources = self.interpolate_data_url(var_data['source'], target_year=target_year)
+
+                # create instance
+                v = GdpVariable(name=var_name,
+                                component=self.component_name,
+                                sources=sources,
+                                target_year=target_year,
+                                **var_data)
+                # assess
+                v(**kwargs)
+
+    def interpolate_data_url(self, source: str, target_year: int):
+        """
+        Interpolate data from source to target year.
+        """
+        with Session() as session:
+            hostname = session.get_blob_service_account_url()
+            parts = source.split(":", 2)
+            pathname = parts[2]
+            source = f"{hostname}/{pathname}"
+
+        if 2000 <= target_year <= 2020:
+            return [source.replace("{year}", str(target_year))]
+
+        if target_year < 2000:
+            return [source.replace("{year}", "2000")]
+
+        if target_year > 2100:
+            return [source.replace("{year}", "2100/ssp2")]
+
+        lower_year = math.floor(target_year / 5) * 5
+        upper_year = lower_year + 5
+
+        if target_year % 5 == 0:
+            return [source.replace("{year}", f"{target_year}/ssp2")]
+
+        return [
+            source.replace("{year}", f"{lower_year}/ssp2"),
+            source.replace("{year}", f"{upper_year}/ssp2"),
+        ]
+
+
+
+
+class GdpVariable(Variable):
+
+    @property
+    def affected_path(self):
+        path, file_name = os.path.split(self.local_path)
+        fname, ext = os.path.splitext(file_name)
+        return os.path.join(path, f'{fname}_affected{ext}')
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        project = Project(path=os.getcwd())
+        geopackage_path = project.geopackage_file_path
+        output_filename = f"{self.component}.tif"
+        self.local_path = os.path.join(os.path.dirname(geopackage_path), self.component,str(self.target_year), output_filename)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Assess a variable. Essentially this means a series of steps in a specific order:
+            - download
+            - preprocess
+            - analysis/zonal stats
+
+        :param kwargs:
+        :return:
+        """
+
+        force_compute = kwargs.get('force_compute', False)
+        progress: Progress = kwargs.get('progress', Progress())
+        variable_task = None
+        if progress is not None:
+            variable_task = progress.add_task(
+                description=f'[blue] Assessing {self.component}->{self.name}', total=None)
+
+        self.download(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress.update(variable_task, description=f'[blue] Downloaded {self.component}->{self.name}')
+
+        self.evaluate(**kwargs)
+        if progress is not None and variable_task is not None:
+            progress.update(variable_task, description=f'[blue] Assessed {self.component}->{self.name}')
+
+
+    def download(self, force_compute=False, **kwargs):
+        project = Project(os.getcwd())
+        progress: Progress = kwargs.get('progress', Progress())
+
+        download_task = None
+        if progress is not None:
+            download_task = progress.add_task(
+                description=f'[red] Downloading {self.name}', total=None)
+
+        if force_compute == False and os.path.exists(self.local_path):
+            if not os.path.exists(self.affected_path):
+                self._compute_affected_()
+            if progress is not None and download_task is not None:
+                progress.update(download_task, description=f'[red] File: {self.local_path} exists. Downloading was skipped')
+                progress.remove_task(download_task)
+            return self.local_path
+
+        local_sources = list()
+
+        if progress is not None and download_task is not None:
+            progress.update(download_task, description=f'[red] Start downloading sources', total=len(self.sources))
+        for source in self.sources:
+            src_path = source
+            hostname, pathname = src_path.split('/gdp/', 1)
+            local_path = os.path.join(project.data_folder, self.component, pathname)
+            tmp_local_path = f"{local_path}.tmp"
+            source_folder = os.path.dirname(tmp_local_path)
+            if not os.path.exists(source_folder):
+                os.makedirs(source_folder)
+            logger.debug(f'Going to download {src_path} to {tmp_local_path}')
+
+            download_raster(
+                src_dataset_path=src_path,
+                src_band=1,
+                dst_dataset_path=tmp_local_path,
+                polygons_dataset_path=project.geopackage_file_path,
+                polygons_layer_name=project.polygons_layer_name,
+                progress=progress
+            )
+
+            with gdal.config_options({
+                'GDAL_HTTP_MERGE_CONSECUTIVE_RANGES': 'YES',
+                'GDAL_CACHEMAX': '512',
+                'GDAL_NUMTHREADS': '4'
+            }):
+                geo.import_raster(
+                    source=tmp_local_path, dst=local_path, target_srs=project.target_srs,
+                    crop_ds=project.geopackage_file_path, crop_layer_name=project.polygons_layer_name,
+                    return_handle=False,
+                    ## warpOptions come now
+                    warpMemoryLimit=1024,
+                )
+            if os.path.exists(tmp_local_path):
+                os.remove(tmp_local_path)
+
+            local_sources.append(local_path)
+
+            if progress is not None and download_task is not None:
+                progress.update(download_task, description=f'[red] Downloaded {local_path}', advance=1)
+
+        target_file = local_sources[0]
+        if len(local_sources) == 2:
+            if progress is not None and download_task is not None:
+                progress.update(download_task, description=f'[red] Interpolating data for {self.target_year}', total=None)
+            # interpolate target year data from two
+            target_file = self.interpolate_target_year(local_sources)
+
+            if progress is not None and download_task is not None:
+                progress.update(download_task, description=f'[red] Interpolated data for {self.target_year}')
+
+        shutil.move(target_file, self.local_path)
+        shutil.rmtree(os.path.dirname(target_file))
+
+        if progress and download_task:
+            progress.remove_task(download_task)
+
+        self._compute_affected_(**kwargs)
+
+    def _compute_affected_(self, **kwargs):
+        if geo.is_raster(self.local_path):
+            progress: Progress = kwargs.get('progress', Progress())
+
+            affect_task = None
+            if progress is not None:
+                affect_task = progress.add_task(
+                    description=f'[red] masking downloaded data by affected area', total=None)
+
+            project = Project(os.getcwd())
+            affected_local_path = self.affected_path
+            ds = Calc(calc='local_path*mask', outfile=affected_local_path, projectionCheck=True, format='GTiff',
+                      creation_options=GTIFF_CREATION_OPTIONS, quiet=False, overwrite=True,
+                      NoDataValue=None,
+                      local_path=self.local_path, mask=project.raster_mask)
+            ds = None
+            assert os.path.exists(self.affected_path), f'Failed to compute {self.affected_path}'
+
+            if progress is not None and affect_task is not None:
+                progress.update(affect_task, description=f'[red] computed masked data for affected area')
+                progress.remove_task(affect_task)
+            return affected_local_path
+
+    def interpolate_target_year(self, local_sources: List[str]):
+        target_year = self.target_year
+
+        year_pattern = re.compile(r"/gdp/(\d{4})/ssp2")
+        years_paths = [(int(year_pattern.search(path).group(1)), path) for path in local_sources]
+        (A_year, A_path), (B_year, B_path) = sorted(years_paths)
+
+        output_file = A_path.replace(str(A_year), str(target_year))
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+
+        # predict target year data by using linear regression from two years data
+        ds = Calc(
+            A=A_path,
+            B=B_path,
+            outfile=output_file,
+            calc=f"A + (B - A) * (({target_year} - {A_year}) / ({B_year} - {A_year}))",
+            projectionCheck=True,
+            quiet=False,
+            overwrite=True,
+            format="GTiff",
+            creation_options=GTIFF_CREATION_OPTIONS,
+            NoDataValue=None
+        )
+        ds = None
+
+        # cleanup
+        for path in local_sources:
+            year_folder = os.path.dirname(os.path.dirname(path))
+            if os.path.exists(year_folder):
+                shutil.rmtree(year_folder)
+
+        return output_file
+
+    def compute(self, force_compute=True, **kwargs):
+        assert force_compute, f'invalid force_compute={force_compute}'
+        return self.download(force_compute=force_compute, **kwargs)
+
+    def resolve(self, **kwargs):
+        pass
+
+    def evaluate(self, **kwargs):
+        """
+        make zonal statistics for variable. compute affected variable if project has mask layer.
+        """
+        variable_name = f"{self.name}_{self.target_year}"
+
+        progress: Progress = kwargs.get('progress', Progress())
+        evaluate_task = None
+        if progress is not None:
+            evaluate_task = progress.add_task(
+                description=f'[red] Going to evaluate {variable_name} in {self.component} component', total=None)
+
+        dst_layer = f'stats.{self.component}'
+        project = Project(path=os.getcwd())
+        layers = gpd.list_layers(project.geopackage_file_path)
+        lnames = layers.name.tolist()
+        if dst_layer in lnames:
+            polygons_layer = dst_layer
+        else:
+            polygons_layer = constants.POLYGONS_LAYER_NAME
+
+        if self.operator:
+            assert os.path.exists(self.local_path), f'{self.local_path} does not exist'
+
+            if progress is not None and evaluate_task is not None:
+                progress.update(evaluate_task, description=f'[red] Evaluating variable {variable_name} using zonal stats')
+
+            # raster variable, run zonal stats
+            src_rasters = [self.local_path]
+            var_ops = [(variable_name, self.operator)]
+
+            if project.raster_mask is not None:
+                affected_local_path = self.affected_path
+                src_rasters.append(affected_local_path)
+                var_ops.append((f'{variable_name}_affected', self.operator))
+
+            gdf = zst(src_rasters=src_rasters,
+                      polygon_ds=project.geopackage_file_path,
+                      polygon_layer=polygons_layer, vars_ops=var_ops
+                      )
+
+            if progress is not None and evaluate_task is not None:
+                progress.update(evaluate_task, description=f'[red] Evaluated variable {variable_name} using zonal stats')
+
+            if progress is not None and evaluate_task is not None:
+                progress.update(evaluate_task,
+                                description=f'[red] Writing {variable_name} to {project.geopackage_file_path}:{dst_layer}')
+
+            gdf.to_file(project.geopackage_file_path, layer=dst_layer, driver="GPKG", overwrite=True)
+        else:
+            progress.update(evaluate_task,
+                            description=f'[red] {variable_name} was skipped because of lack of operator definition.')
+
+        if progress and evaluate_task:
+            progress.remove_task(evaluate_task)

--- a/cbsurge/components/gdp/__init__.py
+++ b/cbsurge/components/gdp/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import re
 import logging

--- a/cbsurge/components/gdp/variables.py
+++ b/cbsurge/components/gdp/variables.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+import logging
+from cbsurge.session import Session
+
+logger = logging.getLogger(__name__)
+
+UNDP_AZURE_GDP_PATH = 'az:{account_name}:{stac_container_name}/gdp/{year}/gdp.tif'
+
+
+def generate_variables():
+    """
+    Generate GDP variables dict
+    :return RWI variables definition
+    """
+
+    license = "Creative Commons Attribution 4.0 International"
+    attribution = "Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios"
+
+    variables = OrderedDict()
+
+    with Session() as session:
+            source = UNDP_AZURE_GDP_PATH.replace("{account_name}", session.get_account_name()).replace("{stac_container_name}", session.get_stac_container_name())
+
+            for operator in ['sum', 'mean', 'min', 'max']:
+                variables[f'gdp_{operator}'] = dict(
+                    title=f'GDP {operator}',
+                    source=source,
+                    operator=operator,
+                    license=license,
+                    attribution=attribution,
+                )
+    return variables

--- a/cbsurge/components/population/variables.py
+++ b/cbsurge/components/population/variables.py
@@ -41,6 +41,9 @@ def generate_variables(root=UNDP_AZURE_WPOP_PATH, aggregate=AGGREGATE, sexes=SEX
     :param age_groups:
     :return:
     """
+    license = "Creative Commons Attribution 4.0 International"
+    attribution = "WorldPop"
+
     with Session() as session:
         # if root is same with UNDP_AZURE_WPOP_PATH, replace account name and container name from session object
         if root == UNDP_AZURE_WPOP_PATH:
@@ -61,31 +64,31 @@ def generate_variables(root=UNDP_AZURE_WPOP_PATH, aggregate=AGGREGATE, sexes=SEX
                 path_template = os.path.join(root, sex, age_group, fname_template)
                 sources.append(path_template)
 
-            variables[name] = dict(title=title, source=source, sources=sources, operator='sum')
+            variables[name] = dict(title=title, source=source, sources=sources, operator='sum', license=license, attribution=attribution)
 
             #age group aggregates
             name = f'{age_group}_{aggregate}'
             title = f'{age_group.capitalize()} population'
             source = os.path.join(aggregate_root, f'{{country}}_{age_group}_{aggregate}.tif')
             sources = '+'.join([f'{e}_{age_group}' for e in sexes])
-            variables[name] = dict(title=title, source=source, sources=sources, operator='sum')
+            variables[name] = dict(title=title, source=source, sources=sources, operator='sum', license=license, attribution=attribution)
         # sex group aggregates
         name = f'{sex}_{aggregate}'
         title = f'{sex.capitalize()} population'
         source = os.path.join(aggregate_root, f'{{country}}_{sex}_{aggregate}.tif')
         sources = '+'.join([f'{sex}_{e[0]}' for e in age_groups])
-        variables[name] = dict(title=title, source=source, sources=sources, operator='sum')
+        variables[name] = dict(title=title, source=source, sources=sources, operator='sum', license=license, attribution=attribution)
     #total aggregate
     name = aggregate
     title = f'{aggregate.capitalize()} population'
     source = os.path.join(aggregate_root, f'{{country}}_{aggregate}.tif')
     sources = '+'.join([f'{e}_{aggregate}' for e in SEXES])
-    variables[name] = dict(title=title, source=source, sources=sources, operator='sum')
+    variables[name] = dict(title=title, source=source, sources=sources, operator='sum', license=license, attribution=attribution)
 
     #dependencies
-    variables['dependency'] = dict(title='Total dependency ratio', sources='((child_total+elderly_total)/active_total)*100')
-    variables['child_dependency'] = dict(title='Child dependency ratio', sources='(child_total/active_total)*100')
-    variables['elderly_dependency'] = dict(title='Elderly dependency ratio', sources='(elderly_total/active_total)*100' )
+    variables['dependency'] = dict(title='Total dependency ratio', sources='((child_total+elderly_total)/active_total)*100', license=license, attribution=attribution)
+    variables['child_dependency'] = dict(title='Child dependency ratio', sources='(child_total/active_total)*100', license=license, attribution=attribution)
+    variables['elderly_dependency'] = dict(title='Elderly dependency ratio', sources='(elderly_total/active_total)*100', license=license, attribution=attribution)
     return variables
 
 

--- a/cbsurge/components/roads/variables.py
+++ b/cbsurge/components/roads/variables.py
@@ -11,6 +11,9 @@ def generate_variables():
 
     variables = OrderedDict()
 
+    license = "Creative Commons Zero 1.0 Universal"
+    attribution = "Global biodiversity model for policy support, GLOBIO"
+
     for operator in ['sum', 'count']:
         name = operator
         if operator == 'sum':
@@ -20,6 +23,8 @@ def generate_variables():
             source='geohub:/api/datasets/300da70781b7a53808aab824543e6c2b',
             operator=operator,
             percentage=True,
+            license=license,
+            attribution=attribution,
         )
 
     return variables

--- a/cbsurge/components/rwi/variables.py
+++ b/cbsurge/components/rwi/variables.py
@@ -11,10 +11,15 @@ def generate_variables():
 
     variables = OrderedDict()
 
+    license = "Creative Commons BY 4.0"
+    attribution = "Data for Good at Meta"
+
     for operator in ['mean', 'min', 'max']:
         variables[f'rwi_{operator}'] = dict(
             title=f'{operator} of relative wealth index',
             source='geohub:/api/datasets/fcde6ab53a79657a27906b3248a1979d',
-            operator=operator
+            operator=operator,
+            license=license,
+            attribution=attribution
         )
     return variables

--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -9,6 +9,7 @@ from cbsurge.components.rwi.variables import generate_variables as gen_rwi_vars
 from cbsurge.components.roads.variables import generate_variables as gen_road_vars
 from cbsurge.components.electricity.variables import generate_variables as gen_electric_vars
 from cbsurge.components.deprivation.variables import generate_variables as gen_depriv_vars
+from cbsurge.components.gdp.variables import generate_variables as gen_gdp_vars
 from cbsurge.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def setup_prompt(session: Session):
             "rwi": gen_rwi_vars(),
             "deprivation": gen_depriv_vars(),
             "electricity": gen_electric_vars(),
+            "gdp": gen_gdp_vars(),
         }
     }
     session.config.update(vars_dict)

--- a/cbsurge/util/download_geodata.py
+++ b/cbsurge/util/download_geodata.py
@@ -506,6 +506,10 @@ def download_raster( src_dataset_path=None, src_band=1,
                                 done = [f.done() for f in futures]
                                 if nblocks == 0 or all(done):
                                     stop_event.set()
+
+                                    if progress and total_task is not None:
+                                        progress.remove_task(total_task)
+
                                     break
                                 s = random.random()  # this one is necessary for ^C/KeyboardInterrupt
                                 time.sleep(s)


### PR DESCRIPTION
- fixes #63 
  - compute sum/min/max/mean of GDP for each polygon of a project
  - compute affected version of each variable if project mask is provided
  - Use GDP data for target year if it is available.
  - If GDP data is not available within forecasting data between 2020 and 2100, get the closest two years' data to interpolate target year's GDP data by using linear regression.

- fixes #276

added data license and attribution for each component variable setting. The latest config.json is like below

<details>
<summary>config.json</summary>

```json
{
    "root_data_folder": "~/cbsurge",
    "account_name": "undpgeohub",
    "publish_container_name": "rapida",
    "stac_container_name": "stacdata",
    "file_share_name": "cbrapida",
    "geohub_endpoint": "https://geohub.data.undp.org",
    "variables": {
        "population": {
            "male_child": {
                "title": "Male child population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_male_child.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/child/{country_lower}_m_0_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/child/{country_lower}_m_1_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/child/{country_lower}_m_10_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/child/{country_lower}_m_5_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "child_total": {
                "title": "Child population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_child_total.tif",
                "sources": "male_child+female_child",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "male_active": {
                "title": "Male active population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_male_active.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_35_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_40_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_45_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_15_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_50_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_20_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_55_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_25_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_60_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/active/{country_lower}_m_30_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "active_total": {
                "title": "Active population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_active_total.tif",
                "sources": "male_active+female_active",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "male_elderly": {
                "title": "Male elderly population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_male_elderly.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/elderly/{country_lower}_m_80_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/elderly/{country_lower}_m_65_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/elderly/{country_lower}_m_75_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/male/elderly/{country_lower}_m_70_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "elderly_total": {
                "title": "Elderly population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_elderly_total.tif",
                "sources": "male_elderly+female_elderly",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "male_total": {
                "title": "Male population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_male_total.tif",
                "sources": "male_child+male_active+male_elderly",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "female_child": {
                "title": "Female child population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_female_child.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/child/{country_lower}_f_0_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/child/{country_lower}_f_1_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/child/{country_lower}_f_10_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/child/{country_lower}_f_5_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "female_active": {
                "title": "Female active population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_female_active.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_35_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_40_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_45_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_15_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_50_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_20_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_55_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_25_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_60_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/active/{country_lower}_f_30_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "female_elderly": {
                "title": "Female elderly population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_female_elderly.tif",
                "sources": [
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/elderly/{country_lower}_f_80_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/elderly/{country_lower}_f_65_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/elderly/{country_lower}_f_75_{year}_constrained_UNadj.tif",
                    "az:undpgeohub:stacdata/worldpop/{year}/{country}/female/elderly/{country_lower}_f_70_{year}_constrained_UNadj.tif"
                ],
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "female_total": {
                "title": "Female population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_female_total.tif",
                "sources": "female_child+female_active+female_elderly",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "total": {
                "title": "Total population",
                "source": "az:undpgeohub:stacdata/worldpop/{year}/{country}/aggregate/{country}_total.tif",
                "sources": "male_total+female_total",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "dependency": {
                "title": "Total dependency ratio",
                "sources": "((child_total+elderly_total)/active_total)*100",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "child_dependency": {
                "title": "Child dependency ratio",
                "sources": "(child_total/active_total)*100",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            },
            "elderly_dependency": {
                "title": "Elderly dependency ratio",
                "sources": "(elderly_total/active_total)*100",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "WorldPop"
            }
        },
        "buildings": {
            "nbuildings": {
                "title": "Number of buildings",
                "source": "/vsicurl/https://data.source.coop/vida/google-microsoft-osm-open-buildings/flatgeobuf/by_country/country_iso={country}/{country}.fgb::{country}",
                "operator": "count",
                "percentage": true,
                "license": "Open Data Commons Open Database License (ODbL)",
                "attribution": "Google, Microsoft, VIDA, Protomaps"
            },
            "buildings_area": {
                "title": "Buildings surface area",
                "source": "/vsicurl/https://data.source.coop/vida/google-microsoft-osm-open-buildings/flatgeobuf/by_country/country_iso={country}/{country}.fgb::{country}",
                "operator": "sum",
                "percentage": true,
                "license": "Open Data Commons Open Database License (ODbL)",
                "attribution": "Google, Microsoft, VIDA, Protomaps"
            }
        },
        "roads": {
            "roads_length": {
                "title": "Total length of roads",
                "source": "geohub:/api/datasets/300da70781b7a53808aab824543e6c2b",
                "operator": "sum",
                "percentage": true,
                "license": "Creative Commons Zero 1.0 Universal",
                "attribution": "Global biodiversity model for policy support, GLOBIO"
            },
            "roads_count": {
                "title": "Total count of roads",
                "source": "geohub:/api/datasets/300da70781b7a53808aab824543e6c2b",
                "operator": "count",
                "percentage": true,
                "license": "Creative Commons Zero 1.0 Universal",
                "attribution": "Global biodiversity model for policy support, GLOBIO"
            }
        },
        "rwi": {
            "rwi_mean": {
                "title": "mean of relative wealth index",
                "source": "geohub:/api/datasets/fcde6ab53a79657a27906b3248a1979d",
                "operator": "mean",
                "license": "Creative Commons BY 4.0",
                "attribution": "Data for Good at Meta"
            },
            "rwi_min": {
                "title": "min of relative wealth index",
                "source": "geohub:/api/datasets/fcde6ab53a79657a27906b3248a1979d",
                "operator": "min",
                "license": "Creative Commons BY 4.0",
                "attribution": "Data for Good at Meta"
            },
            "rwi_max": {
                "title": "max of relative wealth index",
                "source": "geohub:/api/datasets/fcde6ab53a79657a27906b3248a1979d",
                "operator": "max",
                "license": "Creative Commons BY 4.0",
                "attribution": "Data for Good at Meta"
            }
        },
        "deprivation": {
            "depriv_mean": {
                "title": "Average value of relative deprivation index",
                "source": "geohub:/api/datasets/8b885646578937906c1d2759657f98e4",
                "operator": "mean",
                "license": "Creative Commons Zero (CC0)",
                "attribution": "Center for International Earth Science Information Network - CIESIN - Columbia University"
            },
            "depriv_min": {
                "title": "Smallest value of relative deprivation index",
                "source": "geohub:/api/datasets/8b885646578937906c1d2759657f98e4",
                "operator": "min",
                "license": "Creative Commons Zero (CC0)",
                "attribution": "Center for International Earth Science Information Network - CIESIN - Columbia University"
            },
            "depriv_max": {
                "title": "Largest value of relative deprivation index",
                "source": "geohub:/api/datasets/8b885646578937906c1d2759657f98e4",
                "operator": "max",
                "license": "Creative Commons Zero (CC0)",
                "attribution": "Center for International Earth Science Information Network - CIESIN - Columbia University"
            }
        },
        "electricity": {
            "electricity_length": {
                "title": "Total length of electricity",
                "source": "geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29",
                "operator": "sum",
                "percentage": true,
                "license": "Creative Commons BY 4.0",
                "attribution": "World Bank Group, University of Oxford"
            },
            "electricity_count": {
                "title": "Total count of electricity",
                "source": "geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29",
                "operator": "count",
                "percentage": true,
                "license": "Creative Commons BY 4.0",
                "attribution": "World Bank Group, University of Oxford"
            },
            "electricity_density": {
                "title": "Total density of electricity",
                "source": "geohub:/api/datasets/310aadaa61ea23811e6ecd75905aaf29",
                "operator": "density",
                "percentage": false,
                "license": "Creative Commons BY 4.0",
                "attribution": "World Bank Group, University of Oxford"
            }
        },
        "gdp": {
            "gdp_sum": {
                "title": "GDP sum",
                "source": "az:undpgeohub:stacdata/gdp/{year}/gdp.tif",
                "operator": "sum",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios"
            },
            "gdp_mean": {
                "title": "GDP mean",
                "source": "az:undpgeohub:stacdata/gdp/{year}/gdp.tif",
                "operator": "mean",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios"
            },
            "gdp_min": {
                "title": "GDP min",
                "source": "az:undpgeohub:stacdata/gdp/{year}/gdp.tif",
                "operator": "min",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios"
            },
            "gdp_max": {
                "title": "GDP max",
                "source": "az:undpgeohub:stacdata/gdp/{year}/gdp.tif",
                "operator": "max",
                "license": "Creative Commons Attribution 4.0 International",
                "attribution": "Wang, T., & Sun, F. (2023). Global gridded GDP under the historical and future scenarios"
            }
        }
    }
}
```

</details>