### PR TITLE
fix: improved CLI interface of rapida upload command

### DIFF
--- a/cbsurge/az/fileshare.py
+++ b/cbsurge/az/fileshare.py
@@ -2,50 +2,10 @@ import os
 from collections import deque
 from azure.storage.fileshare import ShareClient
 import logging
-from cbsurge import util
 from cbsurge.session import Session
 from cbsurge.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
-
-def upload_project(project_folder:str = None,  progress=None, overwrite=False, max_concurrency=8 ):
-    """
-    Uploads a folder representing a rapida propject to the Azure  account and file share set through
-    rapida init
-    :param project_folder: str, the full path to the project folder
-    :param progress: optional, instance of rich progress to report upload status
-    :param overwrite: bool, default = false, whether the files in the project located remotely should be overwritten
-    :param max_concurrency: int, the number of threads to use in low level azure api when uploading
-    in case they already exists
-    :return: None
-    """
-    with Session() as session:
-        account_name = session.get_account_name()
-        share_name = session.get_file_share_name()
-        account_url = f'https://{account_name}.file.core.windows.net'
-        project_name = project_folder.split(os.path.sep)[-1]
-        with ShareClient(account_url=account_url,share_name=share_name,
-                         credential=session.get_credential(), token_intent='backup') as sc:
-            with sc.get_directory_client(project_name) as project_dir_client:
-                for root, dirs, files in os.walk(project_folder):
-                    directory_name = os.path.relpath(root, project_folder)
-                    dc = project_dir_client.get_subdirectory_client(directory_name=directory_name)
-                    if not dc.exists():
-                        dc.create_directory()
-                    for name in files:
-                        src_path = os.path.join(root, name)
-                        sfc = dc.get_file_client(name)
-                        web_path = os.path.join(account_url, share_name, dc.directory_path, name)
-                        if sfc.exists and not overwrite:
-                            raise FileExistsError(f'{web_path} already exists. Set overwrite=True to overwrite')
-                        size = os.path.getsize(src_path)
-                        with open(src_path, 'rb') as src:
-                            if progress:
-                                with progress.wrap_file(src,  total=size, description=f'Uploading {name} ',) as up:
-                                    dc.upload_file(name, up,  max_concurrency=max_concurrency)
-                                    up.progress.remove_task(up.task)
-                            else:
-                                dc.upload_file(name, src_path, max_concurrency=max_concurrency)
 
 
 def list_projects():

--- a/cbsurge/project/__init__.py
+++ b/cbsurge/project/__init__.py
@@ -3,7 +3,7 @@ import os
 import click
 import logging
 import sys
-from cbsurge.az.fileshare import list_projects, upload_project, download_project
+from cbsurge.az.fileshare import list_projects, download_project
 from rich.progress import Progress
 from cbsurge.util.setup_logger import setup_logger
 from cbsurge.project.project import Project
@@ -47,25 +47,55 @@ def list():
 
 
 @click.command(short_help=f'upload a RAPIDA project to Azure file share')
-
-@click.argument('project_folder', nargs=1,
-                type=click.Path(exists=True, dir_okay=True, readable=True, resolve_path=True) )
+@click.option('-p', '--project',
+              default=None,
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
+              help="Optional. A project folder with rapida.json can be specified. If not, current directory is considered as a project folder.")
 @click.option('--max_concurrency', default=4, show_default=True, type=int,
               help=f'The number of threads to use when uploading a file')
 @click.option('--overwrite','-o',is_flag=True,default=False,
               help="Whether to overwrite the project in case it already exists."
 )
+@click.option('--debug',
+              is_flag=True,
+              default=False,
+              help="Set log level to debug"
+              )
+def upload(project=None,max_concurrency=4,overwrite=None, debug: bool =False):
+    """
+    Upload an entire project folder to Azure File Share
 
-def upload(project_folder=None,max_concurrency=None,overwrite=None):
+    Usage:
 
-    project_folder = os.path.abspath(project_folder)
-    assert os.path.exists(project_folder), f'{project_folder} does not exist'
+        If you are already in a project folder, run the below command:
+        rapida upload
 
+        If you are not in a project folder, run the below command:
+        rapida upload --project=<project folder path>
+
+        If a project data already exists in Azure File Share, run the below command:
+
+        rapida upload --overwrite
+
+        To use --overwrite, old project data in Azure File Share will be lost.
+    """
+    setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if project is None:
+        project = os.getcwd()
+    else:
+        os.chdir(project)
+        logger.info(f"Upload command is executed at the project folder: {project}")
 
     with Progress() as progress:
-        progress.console.print(f'Going to upload {project_folder} to Azure')
-        upload_project(project_folder=project_folder, progress=progress, overwrite=overwrite, max_concurrency=max_concurrency)
-        progress.console.print(f'Rapida project "{project_folder}" was uploaded successfully to Azure')
+        progress.console.print(f'Going to upload {project} to Azure')
+        prj = Project(path=project)
+        if not prj.is_valid:
+            logger.error(f'Project "{project}" is not a valid RAPIDA project')
+            return
+        prj.upload(progress=progress, overwrite=overwrite, max_concurrency=max_concurrency)
+        progress.console.print(f'Rapida project "{project}" was uploaded successfully to Azure')
+
 
 @click.command(short_help=f'download a RAPIDA project from Azure file share')
 
@@ -129,4 +159,7 @@ def publish(project: str, yes: bool = False, debug: bool =False):
         os.chdir(project)
         logger.info(f"Publish command is executed at the project folder: {project}")
     prj = Project(path=project)
+    if not prj.is_valid:
+        logger.error(f'Project "{project}" is not a valid RAPIDA project')
+        return
     prj.publish(yes=yes)

--- a/cbsurge/project/project.py
+++ b/cbsurge/project/project.py
@@ -282,14 +282,14 @@ class Project:
 
     def upload(self, progress=None, overwrite=False, max_concurrency=8):
         """
-            Uploads a folder representing a rapida propject to the Azure  account and file share set through
-            rapida init
-            :param project_folder: str, the full path to the project folder
-            :param progress: optional, instance of rich progress to report upload status
-            :param overwrite: bool, default = false, whether the files in the project located remotely should be overwritten
-            :param max_concurrency: int, the number of threads to use in low level azure api when uploading
-            in case they already exists
-            :return: None
+        Uploads a folder representing a rapida propject to the Azure account and file share set through rapida init
+
+        :param project_folder: str, the full path to the project folder
+        :param progress: optional, instance of rich progress to report upload status
+        :param overwrite: bool, default = false, whether the files in the project located remotely should be overwritten
+        :param max_concurrency: int, the number of threads to use in low level azure api when uploading
+        in case they already exists
+        :return: None
         """
         with Session() as session:
             account_name = session.get_account_name()

--- a/cbsurge/project/project.py
+++ b/cbsurge/project/project.py
@@ -14,6 +14,7 @@ import geopandas
 import h3
 from osgeo import gdal, ogr, osr
 from pyproj import CRS as pCRS
+from azure.storage.fileshare import ShareClient
 
 from cbsurge import constants
 from cbsurge.admin.osm import fetch_admin
@@ -279,7 +280,45 @@ class Project:
             json.dump(data, cfgf, indent=4)
 
 
-
+    def upload(self, progress=None, overwrite=False, max_concurrency=8):
+        """
+            Uploads a folder representing a rapida propject to the Azure  account and file share set through
+            rapida init
+            :param project_folder: str, the full path to the project folder
+            :param progress: optional, instance of rich progress to report upload status
+            :param overwrite: bool, default = false, whether the files in the project located remotely should be overwritten
+            :param max_concurrency: int, the number of threads to use in low level azure api when uploading
+            in case they already exists
+            :return: None
+        """
+        with Session() as session:
+            account_name = session.get_account_name()
+            share_name = session.get_file_share_name()
+            account_url = f'https://{account_name}.file.core.windows.net'
+            project_name = self._cfg_["name"]
+            project_folder = self.path
+            with ShareClient(account_url=account_url, share_name=share_name,
+                             credential=session.get_credential(), token_intent='backup') as sc:
+                with sc.get_directory_client(project_name) as project_dir_client:
+                    for root, dirs, files in os.walk(project_folder):
+                        directory_name = os.path.relpath(root, project_folder)
+                        dc = project_dir_client.get_subdirectory_client(directory_name=directory_name)
+                        if not dc.exists():
+                            dc.create_directory()
+                        for name in files:
+                            src_path = os.path.join(root, name)
+                            sfc = dc.get_file_client(name)
+                            web_path = os.path.join(account_url, share_name, dc.directory_path, name)
+                            if sfc.exists and not overwrite:
+                                raise FileExistsError(f'{web_path} already exists. Set overwrite=True to overwrite')
+                            size = os.path.getsize(src_path)
+                            with open(src_path, 'rb') as src:
+                                if progress:
+                                    with progress.wrap_file(src, total=size, description=f'Uploading {name} ', ) as up:
+                                        dc.upload_file(name, up, max_concurrency=max_concurrency)
+                                        up.progress.remove_task(up.task)
+                                else:
+                                    dc.upload_file(name, src_path, max_concurrency=max_concurrency)
 
     def publish(self, yes=False):
         """


### PR DESCRIPTION
- moved upload_project function to Project class
- added `-p` option to specify project folder, 
- or users can upload after moving to project folder
- check if project folder is valid for upload/publish command