### PR TITLE
feat: implemented rapida delete command

### DIFF
--- a/cbsurge/az/fileshare.py
+++ b/cbsurge/az/fileshare.py
@@ -2,6 +2,7 @@ import os
 from collections import deque
 from azure.storage.fileshare import ShareClient
 import logging
+import click
 from cbsurge.session import Session
 from cbsurge.util.setup_logger import setup_logger
 
@@ -14,9 +15,8 @@ def list_projects():
     :return: name of the folders
     """
     with Session() as session:
-        account_name = session.get_account_name()
         share_name = session.get_file_share_name()
-        account_url = f'https://{account_name}.file.core.windows.net'
+        account_url = session.get_file_share_account_url()
         with ShareClient(account_url=account_url,share_name=share_name,
                          credential=session.get_credential(), token_intent='backup') as sc:
             for entry in sc.list_directories_and_files():
@@ -79,6 +79,8 @@ def download_project(name:str=None, dst_folder=None, progress=None, overwrite=Fa
     if tasks and progress:
        for _ in range(len(tasks)):
             progress.remove_task(tasks.pop())
+
+
 if __name__ == '__main__':
     logger = setup_logger(name='rapida')
 

--- a/cbsurge/cli.py
+++ b/cbsurge/cli.py
@@ -2,7 +2,7 @@ import logging
 
 from cbsurge.util.setup_logger import setup_logger
 from cbsurge.admin import admin
-from cbsurge.project import create, list, upload, download, publish
+from cbsurge.project import create, list, upload, download, publish, delete
 from cbsurge.initialize import init
 from cbsurge.assess import assess
 from cbsurge.stats import stats
@@ -29,6 +29,7 @@ cli.add_command(create)
 cli.add_command(list)
 cli.add_command(upload)
 cli.add_command(download)
+cli.add_command(delete)
 cli.add_command(publish)
 
 

--- a/cbsurge/project/__init__.py
+++ b/cbsurge/project/__init__.py
@@ -182,6 +182,47 @@ def download(project_name=None, destination_folder=None, max_concurrency=None,ov
     logger.info(f'Project "{project_name}" was downloaded successfully to {project_path}')
 
 
+@click.command(short_help=f'delete a RAPIDA project from Azure file share')
+@click.option('-p', '--project',
+              default=None,
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
+              help="Optional. A project folder with rapida.json can be specified. If not, current directory is considered as a project folder.")
+@click.option('-y', '--yes',
+              is_flag=True,
+              default=False,
+              help="Optional. If True, it will automatically answer yes to prompts. Default is False.")
+@click.option('--debug',
+              is_flag=True,
+              default=False,
+              help="Set log level to debug")
+def delete(project: str, yes: bool = False, debug: bool =False):
+    """
+    Delete a project from local storage and Azure File Share if it was uploaded.
+
+    Usage:
+
+        If you are already in a project folder, run the below command:
+        rapida delete
+
+        If you are not in a project folder, run the below command:
+        rapida delete --project=<project folder path>
+
+        This command shows prompts to confirm deletion of a project to prevent deleting accidentally. If you wish to answer all prompts to yes, use -y or --yes in the command:
+
+        rapida delete --yes
+    """
+    setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if project is None:
+        project = os.getcwd()
+    else:
+        os.chdir(project)
+        logger.info(f"Delete command is executed at the project folder: {project}")
+    prj = Project(path=project)
+    if not prj.is_valid:
+        logger.error(f'Project "{project}" is not a valid RAPIDA project')
+        return
+    prj.delete(yes=yes)
 
 @click.command(short_help=f'publish RAPIDA project results to Azure and GeoHub')
 @click.option('-p', '--project',

--- a/cbsurge/session.py
+++ b/cbsurge/session.py
@@ -300,39 +300,7 @@ class Session(object):
         ac_name = account_name if account_name is not None else self.get_account_name()
         return f"https://{ac_name}.blob.core.windows.net"
 
-    def get_share_service_client(self, account_name: str = None, share_name: str = None) -> ShareServiceClient:
-        """
-        get ShareServiceClient for account url
-
-        If the parameter is not set, use default account name from config.
-
-        Usage example:
-            with Session() as session:
-                share_service_client = session.get_share_service_client(
-                    account_name="undpgeohub",
-                    share_name="cbrapida"
-                )
-
-        Parameters:
-            account_name (str): name of storage account.
-            share_name (str): name of file share.
-
-            both parameters are equivalent to the below URL's bracket places.
-
-            https://{account_name}.file.core.windows.net/{share_name}
-        Returns:
-            ShareServiceClient
-        """
-        credential = self.get_credential()
-        account_url = self.get_file_share_account_url(account_name, share_name)
-        share_service_client = ShareServiceClient(
-            account_url=account_url,
-            credential=credential,
-            token_intent='backup'
-        )
-        return share_service_client
-
-    def get_file_share_account_url(self, account_name: str = None, share_name: str = None) -> str:
+    def get_file_share_account_url(self, account_name: str = None) -> str:
         """
         get blob service account URL
 
@@ -340,11 +308,9 @@ class Session(object):
 
         Parameters:
             account_name (str): Optional. name of storage account url. If the parameter is not set, use default account name from config.
-            share_name (str): name of file share. If the parameter is not set, use default account name from config.
         """
         ac_name = account_name if account_name is not None else self.get_account_name()
-        sh_name = share_name if share_name is not None else self.get_file_share_name()
-        return f"https://{ac_name}.file.core.windows.net/{sh_name}"
+        return f"https://{ac_name}.file.core.windows.net"
 
     def get_components(self):
         """

--- a/tests/cbsurge/test_session.py
+++ b/tests/cbsurge/test_session.py
@@ -9,11 +9,10 @@ def test_session():
         s.set_root_data_folder("~/cbsurge")
 
         assert s.get_blob_service_account_url() == "https://test_account.blob.core.windows.net"
-        assert s.get_file_share_account_url() == "https://test_account.file.core.windows.net/test_share"
+        assert s.get_file_share_account_url() == "https://test_account.file.core.windows.net"
 
         assert s.get_blob_service_account_url(account_name="aaa") == "https://aaa.blob.core.windows.net"
-        assert s.get_file_share_account_url(account_name="aaa") == "https://aaa.file.core.windows.net/test_share"
-        assert s.get_file_share_account_url(account_name="aaa", share_name="bbb") == "https://aaa.file.core.windows.net/bbb"
+        assert s.get_file_share_account_url(account_name="aaa") == "https://aaa.file.core.windows.net"
 
         assert s.get_root_data_folder(False) == "~/cbsurge"
         assert s.get_root_data_folder(True) == os.path.expanduser("~/cbsurge")


### PR DESCRIPTION
- fixed a bug of upload command
- added delete command to delete a project from Azure File Share and local storage

## CLI interface

```shell
rapida delete --help
Usage: rapida delete [OPTIONS]

  Delete a project from local storage and Azure File Share if it was uploaded.

  Usage:

      If you are already in a project folder, run the below command:
      rapida delete

      If you are not in a project folder, run the below command:     rapida
      delete --project=<project folder path>

      This command shows prompts to confirm deletion of a project to prevent
      deleting accidentally. If you wish to answer all prompts to yes, use -y
      or --yes in the command:

      rapida delete --yes

Options:
  -p, --project DIRECTORY  Optional. A project folder with rapida.json can be
                           specified. If not, current directory is considered
                           as a project folder.
  -y, --yes                Optional. If True, it will automatically answer yes
                           to prompts. Default is False.
  --debug                  Set log level to debug
  --help                   Show this message and exit.

```

## Usage

The below is to delete from both local storage and azure file share. Each deletion shows a prompt to ask whether user really want to delete it. If type `yes` or `y`, it is going to delete it from Azure and local storage.

```shell
rapida delete -p /data/kigali
[03/25/25 12:20:39] INFO     Delete command is executed at the project folder: /data/kigali                                                                        __init__.py:220
[03/25/25 12:20:40] INFO     Searching for the project 'kigali' in Azure...                                                                                         project.py:352
Project: kigali was found. Yes to continue deleting it, or No/Enter to exit.  [y/N]: y
[03/25/25 12:20:51] INFO     Successfully deleted the project from Azure: kigali.                                                                                   project.py:365
Do want to continue deleting kigali located in /data/kigali locally? [y/N]: y
[03/25/25 12:20:54] INFO     Successfully deleted the project folder: /data/kigali from local storage.                                                              project.py:373
```

If a project is not uploaded in Azure File Share, but it exists in local, the command still can delete local project folder.

If user is already in a project folder, no need to put `-p` option for project path like below command:

```shell
rapida delete
```