### PR TITLE
fix: check if rapida tool is initialized when command is executed except rapida init

### DIFF
--- a/cbsurge/admin/__init__.py
+++ b/cbsurge/admin/__init__.py
@@ -4,6 +4,7 @@ import os
 
 from cbsurge.admin.osm import fetch_admin as fetch_osm_admin, ADMIN_LEVELS
 from cbsurge.admin.ocha import fetch_admin as fetch_ocha_admin
+from cbsurge.session import is_rapida_initialized
 from cbsurge.util.bbox_param_type import BboxParamType
 import click
 import json
@@ -37,14 +38,11 @@ def save(geojson_dict=None, dst_path=None, layer_name=None):
 
 @click.group(short_help=f'fetch administrative boundaries at various levels from OSM/OCHA')
 def admin():
-
     pass
 
 
 @admin.command(no_args_is_help=True)
-
 @click.argument('destination_path', type=click.Path())
-
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
 @click.option('-l','--admin_level',
@@ -70,17 +68,12 @@ def admin():
     show_default=True,
     help="Precision level for H3 indexing (default is 7)."
 )
-
-
-
 @click.option('--debug',
 
     is_flag=True,
     default=False,
     help="Set log level to debug"
 )
-
-
 def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7, destination_path=None, debug=False,):
     """
     Fetch admin boundaries from OSM
@@ -108,6 +101,9 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     if debug:
         logger.setLevel(logging.DEBUG)
 
+    if not is_rapida_initialized():
+        return
+
     geojson = fetch_osm_admin(bbox=bbox, admin_level=admin_level,osm_level=osm_level, clip=clip, h3id_precision=h3id_precision)
     if not geojson:
         logger.error('Could not extract admin boundaries from OSM for the provided bbox')
@@ -117,9 +113,7 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
 
 
 @admin.command(no_args_is_help=True)
-
 @click.argument('destination_path', type=click.Path())
-
 @click.option('-b', '--bbox', required=True, type=BboxParamType(),
               help='Bounding box xmin/west, ymin/south, xmax/east, ymax/north' )
 @click.option('-l','--admin_level',
@@ -127,7 +121,6 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
                 type=click.IntRange(min=0, max=2, clamp=False),
                 help='UNDP admin level from where to extract the admin features'
                 )
-
 @click.option('--clip',
 
     is_flag=True,
@@ -141,18 +134,12 @@ def osm(bbox=None,admin_level=None, osm_level=None, clip=False, h3id_precision=7
     show_default=True,
     help="Precision level for H3 indexing (default is 7)."
 )
-
-
-
-
 @click.option('--debug',
 
     is_flag=True,
     default=False,
     help="Set log level to debug"
 )
-
-
 def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, destination_path=None, debug=False ):
     """
     Fetch admin boundaries from OCHA COD
@@ -177,6 +164,10 @@ def ocha(bbox=None,admin_level=None,  clip=False, h3id_precision=7, destination_
     logger = logging.getLogger('rapida')
     if debug:
         logger.setLevel(logging.DEBUG)
+
+    if not is_rapida_initialized():
+        return
+
     geojson = fetch_ocha_admin(bbox=bbox, admin_level=admin_level, clip=clip, h3id_precision=h3id_precision)
     if not geojson:
         logger.error('Could not extract admin boundaries from OCHA for the provided bbox')

--- a/cbsurge/assess.py
+++ b/cbsurge/assess.py
@@ -5,7 +5,7 @@ import importlib
 import sys
 import click
 from rich.progress import Progress
-from cbsurge.session import Session
+from cbsurge.session import Session, is_rapida_initialized
 from cbsurge.project import Project
 from cbsurge.util.setup_logger import setup_logger
 
@@ -84,6 +84,10 @@ def assess(ctx, components=None,  variables=None, year=None, force_compute=False
         logger = setup_logger(level=logging.DEBUG)
     else:
         logger = setup_logger()
+
+    if not is_rapida_initialized():
+        return
+
     try:
         current_folder = os.getcwd()
         project = Project(path=current_folder)

--- a/cbsurge/project/__init__.py
+++ b/cbsurge/project/__init__.py
@@ -5,6 +5,8 @@ import logging
 import sys
 from cbsurge.az.fileshare import list_projects, download_project
 from rich.progress import Progress
+
+from cbsurge.session import is_rapida_initialized
 from cbsurge.util.setup_logger import setup_logger
 from cbsurge.project.project import Project
 
@@ -23,6 +25,9 @@ logger = setup_logger()
 
 def create(name=None, polygons=None, mask=None, comment=None):
 
+    if not is_rapida_initialized():
+        return
+
     abs_folder = os.path.abspath(name)
     if os.path.exists(abs_folder):
         logger.error(f'Folder "{name}" already exists in {os.getcwd()}')
@@ -37,6 +42,9 @@ def create(name=None, polygons=None, mask=None, comment=None):
 
 @click.command(short_help=f'list RAPIDA projects/folders located in default Azure file share')
 def list():
+    if not is_rapida_initialized():
+        return
+
     const = '-'*15
     tabs = '\t'*1
     click.echo(f'{const} Available RAPIDA projects {const}')
@@ -83,6 +91,9 @@ def upload(project=None,max_concurrency=4,overwrite=None, debug: bool =False):
         To use --overwrite, old project data in Azure File Share will be lost.
     """
     setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if not is_rapida_initialized():
+        return
 
     if project is None:
         project = os.getcwd()
@@ -146,6 +157,9 @@ def download(project_name=None, destination_folder=None, max_concurrency=None,ov
         To use --overwrite, old project data in local storage will be lost..
     """
     setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if not is_rapida_initialized():
+        return
 
     last_folder = destination_folder.split('/')[-1]
     project_path = destination_folder
@@ -213,6 +227,9 @@ def delete(project: str, yes: bool = False, debug: bool =False):
     """
     setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
 
+    if not is_rapida_initialized():
+        return
+
     if project is None:
         project = os.getcwd()
     else:
@@ -253,6 +270,9 @@ def publish(project: str, yes: bool = False, debug: bool =False):
         If you answer all prompts to yes, use '--yes' option of the command.
     """
     setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if not is_rapida_initialized():
+        return
 
     if project is None:
         project = os.getcwd()

--- a/cbsurge/session.py
+++ b/cbsurge/session.py
@@ -349,6 +349,19 @@ class Session(object):
         component = self.get_component(component=component)
         return component[variable]
 
+
+def is_rapida_initialized():
+    """
+    Check if RAPIDA has been initialized
+
+    :return: boolean if True, config.json exists
+    """
+    with Session() as session:
+        if session.get_config() is None:
+            logger.warning(f"Rapida tool is not initialized. Please run `rapida init` first.")
+            return False
+    return True
+
 # for testing
 # import asyncio
 # async def main():

--- a/cbsurge/stats/__init__.py
+++ b/cbsurge/stats/__init__.py
@@ -1,6 +1,9 @@
 import logging
 import click
+
+from cbsurge.session import is_rapida_initialized
 from cbsurge.stats.zonal_stats import ZonalStats
+from cbsurge.util.setup_logger import setup_logger
 
 
 @click.group(short_help=f'compute zonal statistics using exactextract')
@@ -77,7 +80,10 @@ def compute(
     Example: \n
         rapida stats compute ./cbsurge/stats/tests/assets/admin2.geojson ./cbsurge/stats/tests/assets/admin2_stats.fgb -r ./cbsurge/stats/tests/assets/rwa_m_5_2020_constrained_UNadj.tif -r ./cbsurge/stats/tests/assets/rwa_f_5_2020_constrained_UNadj.tif -o sum -c male_5_sum -c female_5_sum
     """
-    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
+    setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
+
+    if not is_rapida_initialized():
+        return
 
     with ZonalStats(input_file, target_crs="ESRI:54009") as st:
         st.compute(raster, operations=operation, operation_cols=column)


### PR DESCRIPTION
It shows error message like below if users have not done `rapida init` yet.

```shell
rapida assess
[03/26/25 06:52:41] WARNING  Rapida tool is not initialized. Please run `rapida init` first.    
```