### PR TITLE
rm tensorflow to be able to deploy to web app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "msal",
     "playwright",
     "pystac_client",
-    "tensorflow",
     "pystac_client",
     "requests-oauthlib",
     "pystac_client",


### PR DESCRIPTION
The docker image is too lartge (8.6 GB) and can no be deployed  with AZ web app. By removing the tensorflow from the dep it should be possible to deploy rapida server