### PR TITLE
fix: simplify `rapida init` command interface and message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,14 @@ JUPYTER_USERS=
 TENANT_ID=
 CLIENT_ID=
 USER=
+
+# azure blob storage account name for rapida tool. default is 'undpgeohub'
+AZURE_STORAGE_ACCOUNT=
+# container name of azure blob storage for publishing. default is 'rapida'
+AZURE_PUBLISH_CONTAINER_NAME=
+# container name of azure blob storage for UNDP STAC. default is 'stacdata'
+AZURE_STAC_CONTAINER_NAME=
+# file share name of storage account to store project data. default is 'cbrapida'
+AZURE_FILE_SHARE_NAME=
+# geohub endpoint. default is 'https://geohub.data.undp.org'
+GEOHUB_ENDPOINT=

--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -15,6 +15,11 @@ from cbsurge.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
 
+AZURE_STORAGE_ACCOUNT=os.environ.get("AZURE_STORAGE_ACCOUNT", "undpgeohub")
+AZURE_PUBLISH_CONTAINER_NAME=os.environ.get("AZURE_PUBLISH_CONTAINER_NAME", "rapida")
+AZURE_STAC_CONTAINER_NAME=os.environ.get("AZURE_STAC_CONTAINER_NAME", "stacdata")
+AZURE_FILE_SHARE_NAME=os.environ.get("AZURE_FILE_SHARE_NAME", "cbrapida")
+GEOHUB_ENDPOINT=os.environ.get("GEOHUB_ENDPOINT", "https://geohub.data.undp.org")
 
 def setup_prompt(session: Session):
     auth = session.authenticate()
@@ -53,32 +58,20 @@ def setup_prompt(session: Session):
     session.set_root_data_folder(root_data_folder)
 
     # azure blob container setting
-    account_name = click.prompt('Please enter account name for UNDP Azure. Enter to skip if use default value',
-                                type=str, default='undpgeohub')
-    session.set_account_name(account_name)
-    click.echo(f"account name: {account_name}")
-
-    publish_container_name = click.prompt('Please enter UNDP Azure container name of publishing project outcome. Enter to skip if use default value',
-                                  type=str, default='rapida')
-    session.set_publish_container_name(publish_container_name)
-    click.echo(f"publish container name: {publish_container_name}")
-
-    stac_container_name = click.prompt('Please enter container name for UNDP Azure STAC. Enter to skip if use default value',
-                                  type=str, default='stacdata')
-    session.set_stac_container_name(stac_container_name)
-    click.echo(f"stac container name: {stac_container_name}")
+    session.set_account_name(AZURE_STORAGE_ACCOUNT)
+    logger.debug(f"account name: {session.get_account_name()}")
+    session.set_publish_container_name(AZURE_PUBLISH_CONTAINER_NAME)
+    logger.debug(f"publish container name: {session.get_publish_container_name()}")
+    session.set_stac_container_name(AZURE_STAC_CONTAINER_NAME)
+    logger.debug(f"stac container name: {session.get_stac_container_name()}")
 
     # azure file share setting
-    share_name = click.prompt('Please enter share name for UNDP Azure. Enter to skip if use default value',
-                              type=str, default='cbrapida')
-    session.set_file_share_name(share_name)
-    click.echo(f"file share name: {share_name}")
+    session.set_file_share_name(AZURE_FILE_SHARE_NAME)
+    logger.debug(f"file share name: {session.get_file_share_name()}")
 
     # geohub endpoint setting
-    geohub_endpoint = click.prompt('Please enter URL of GeoHub endpoint. Enter to skip if use default value',
-                              type=str, default='https://geohub.data.undp.org')
-    session.set_geohub_endpoint(geohub_endpoint)
-    click.echo(f"GeoHub endpoint: {geohub_endpoint}")
+    session.set_geohub_endpoint(GEOHUB_ENDPOINT)
+    logger.debug(f"GeoHub endpoint: {session.get_geohub_endpoint()}")
 
     session.save_config()
     vars_dict = {

--- a/cbsurge/initialize.py
+++ b/cbsurge/initialize.py
@@ -1,7 +1,6 @@
 import logging
 import click
 import os
-import shutil
 from cbsurge.session import Session
 from cbsurge.components.population.variables import generate_variables as gen_pop_vars
 from cbsurge.components.buildings.variables import generate_variables as gen_bldgs_vars
@@ -13,7 +12,9 @@ from cbsurge.components.landuse.variables import generate_variables as gen_landu
 from cbsurge.components.gdp.variables import generate_variables as gen_gdp_vars
 from cbsurge.util.setup_logger import setup_logger
 
+
 logger = logging.getLogger(__name__)
+
 
 AZURE_STORAGE_ACCOUNT=os.environ.get("AZURE_STORAGE_ACCOUNT", "undpgeohub")
 AZURE_PUBLISH_CONTAINER_NAME=os.environ.get("AZURE_PUBLISH_CONTAINER_NAME", "rapida")
@@ -32,30 +33,6 @@ def setup_prompt(session: Session):
     else:
         click.echo("Authentication successful.")
 
-    click.echo("We need more information to setup from you.")
-
-    # project root data folder
-    root_data_folder = None
-    absolute_root_data_folder = None
-    while not(root_data_folder is not None and os.path.exists(absolute_root_data_folder)):
-        data_folder = click.prompt("Please enter project root folder to store all data. Enter to skip if use default value", default="~/cbsurge")
-        absolute_root_data_folder = os.path.expanduser(data_folder)
-
-        if os.path.exists(absolute_root_data_folder):
-            if click.confirm("The folder already exists. Yes to overwrite, No/Enter to use existing folder", default=False):
-                shutil.rmtree(absolute_root_data_folder)
-                click.echo(f"Removed folder {absolute_root_data_folder}")
-                os.makedirs(absolute_root_data_folder)
-                click.echo(f"The project root folder was created at {absolute_root_data_folder}")
-                root_data_folder = data_folder
-            else:
-                click.echo(f"Use {absolute_root_data_folder} as the root folder.")
-                root_data_folder = data_folder
-        else:
-            os.makedirs(absolute_root_data_folder)
-            click.echo(f"The project root folder was created at {absolute_root_data_folder}")
-            root_data_folder = data_folder
-    session.set_root_data_folder(root_data_folder)
 
     # azure blob container setting
     session.set_account_name(AZURE_STORAGE_ACCOUNT)
@@ -88,7 +65,8 @@ def setup_prompt(session: Session):
     }
     session.config.update(vars_dict)
     session.save_config()
-    click.echo('Setting up was successfully done!')
+    click.echo(f"Initialization was done. config file was saved to {session.get_config_file_path()}")
+
 
 
 @click.command(short_help='initialize RAPIDA tool')

--- a/cbsurge/session.py
+++ b/cbsurge/session.py
@@ -85,24 +85,6 @@ class Session(object):
         self.config[key] = value
 
 
-    def set_root_data_folder(self, folder_name):
-        self.set_config_value_by_key("root_data_folder", folder_name)
-
-    def get_root_data_folder(self, is_absolute_path=True):
-        """
-        get root data folder
-
-        Parameters:
-            is_absolute_path (bool): Optional. If true, return absolute path, otherwise relative path. Default is True.
-        Returns:
-            root data folder path (str)
-        """
-        root_data_folder = self.get_config_value_by_key("root_data_folder")
-        if is_absolute_path:
-            return  os.path.expanduser(root_data_folder)
-        else:
-            return root_data_folder
-
     def set_account_name(self, account_name: str):
         self.set_config_value_by_key("account_name", account_name)
 
@@ -137,8 +119,6 @@ class Session(object):
         """
         Save config.json under user directory as ~/.cbsurge/config.json
         """
-        if self.get_root_data_folder() is None:
-            raise RuntimeError(f"root_data_folder is not set")
         if self.get_account_name() is None:
             raise RuntimeError(f"account_name is not set")
         if self.get_stac_container_name() is None:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,12 +11,19 @@ services:
       - ./cbsurge:/app/cbsurge # mount app folder to container
       - ./tests:/app/tests
       # uncomment to mount token info from local
-      # - ~/.cbsurge/token_cache.json:/root/.cbsurge/token_cache.json
+      # - ~/.cbsurge:/root/.cbsurge
+      # uncomment to mount data folder from local
+      # - ./data:/data
     entrypoint: "/app/entrypoint.sh"
-#    entrypoint: "pipenv run jupyterhub"
     ports:
       - 8100:8000
     environment:
       - JUPYTER_USERS=${JUPYTER_USERS:-''}
       - TENANT_ID=${TENANT_ID:-''}
       - CLIENT_ID=${CLIENT_ID:-''}
+      - USER=${USER:-''}
+      - AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT:-''}
+      - AZURE_PUBLISH_CONTAINER_NAME=${AZURE_PUBLISH_CONTAINER_NAME:-''}
+      - AZURE_STAC_CONTAINER_NAME=${AZURE_STAC_CONTAINER_NAME:-''}
+      - AZURE_FILE_SHARE_NAME=${AZURE_FILE_SHARE_NAME:-''}
+      - GEOHUB_ENDPOINT=${GEOHUB_ENDPOINT:-''}

--- a/tests/cbsurge/test_session.py
+++ b/tests/cbsurge/test_session.py
@@ -6,13 +6,9 @@ def test_session():
     with Session() as s:
         s.set_account_name("test_account")
         s.set_file_share_name("test_share")
-        s.set_root_data_folder("~/cbsurge")
 
         assert s.get_blob_service_account_url() == "https://test_account.blob.core.windows.net"
         assert s.get_file_share_account_url() == "https://test_account.file.core.windows.net"
 
         assert s.get_blob_service_account_url(account_name="aaa") == "https://aaa.blob.core.windows.net"
         assert s.get_file_share_account_url(account_name="aaa") == "https://aaa.file.core.windows.net"
-
-        assert s.get_root_data_folder(False) == "~/cbsurge"
-        assert s.get_root_data_folder(True) == os.path.expanduser("~/cbsurge")


### PR DESCRIPTION
fixes #320

new rapida init produces prompts like below

```shell
rapida init
Welcome to rapida CLI tool!
Your setup has already been done. Would you like to do setup again? [y/N]: y
[04/11/25 08:23:19] INFO     Token cached at /root/.cbsurge/zb5ZCVLrXSVDa8GXWV1lUmS_J.bin will expire in 3284.513695 secs                                                         surgeauth.py:260
Authentication successful.
Initialization was done. config file was saved to /root/.cbsurge/config.json
```

all internally used variables are exposed as environmental variables. those are indicated at `.env.example`

```
# azure blob storage account name for rapida tool. default is 'undpgeohub'
AZURE_STORAGE_ACCOUNT=
# container name of azure blob storage for publishing. default is 'rapida'
AZURE_PUBLISH_CONTAINER_NAME=
# container name of azure blob storage for UNDP STAC. default is 'stacdata'
AZURE_STAC_CONTAINER_NAME=
# file share name of storage account to store project data. default is 'cbrapida'
AZURE_FILE_SHARE_NAME=
# geohub endpoint. default is 'https://geohub.data.undp.org'
GEOHUB_ENDPOINT=
```

if environmental variables are missing, default value is used.

unused root data folder setting in session class was deleted now.