### PR TITLE
fix: added attibution and license for landuse component

### DIFF
--- a/cbsurge/components/landuse/variables.py
+++ b/cbsurge/components/landuse/variables.py
@@ -7,15 +7,23 @@ def generate_variables():
     # https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c
     source = "earth-search:sentinel-2-l1c"
 
+    license = "Proprietary"
+    dynamic_world_citation = "Brown, C.F., Brumby, S.P., Guzder-Williams, B. et al. (2022). Dynamic World, Near real-time global 10 m land use land cover mapping. Scientific Data, 9(1)."
+    attribution = f"ESA, Sinergise, AWS, Element 84, {dynamic_world_citation}"
+
     variables = OrderedDict()
     variables['built_area'] = dict(title='Built-up area',
                                    source=f"{source}:6",
                                    operator='sum',
                                    percentage=True,
+                                   license=license,
+                                   attribution=attribution,
                                    )
     variables['crops_area'] = dict(title='Cropland area',
                                    source=f"{source}:4",
                                    operator='sum',
                                    percentage=True,
+                                   license = license,
+                                   attribution = attribution,
                                    )
     return variables


### PR DESCRIPTION
fixes #330

new landuse component setting is like below

```json
        "landuse": {
            "built_area": {
                "title": "Built-up area",
                "source": "earth-search:sentinel-2-l1c:6",
                "operator": "sum",
                "percentage": true,
                "license": "Proprietary",
                "attribution": "ESA, Sinergise, AWS, Element 84, Brown, C.F., Brumby, S.P., Guzder-Williams, B. et al. (2022). Dynamic World, Near real-time global 10 m land use land cover mapping. Scientific Data, 9(1)."
            },
            "crops_area": {
                "title": "Cropland area",
                "source": "earth-search:sentinel-2-l1c:4",
                "operator": "sum",
                "percentage": true,
                "license": "Proprietary",
                "attribution": "ESA, Sinergise, AWS, Element 84, Brown, C.F., Brumby, S.P., Guzder-Williams, B. et al. (2022). Dynamic World, Near real-time global 10 m land use land cover mapping. Scientific Data, 9(1)."
            }
        },
```