### PR TITLE
fix: check only relevant component variable selected. improved help message

### DIFF
--- a/cbsurge/cli/assess.py
+++ b/cbsurge/cli/assess.py
@@ -44,19 +44,77 @@ def getComponents():
 available_components = getComponents()
 
 
-def getVariables():
+# def getVariables():
+#     try:
+#         with Session() as session:
+#             variables = []
+#             for component in available_components:
+#                 res = session.get_variables(component=component)
+#                 variables.extend(res)
+#             return list(variables)
+#     except:
+#         return []
+#
+#
+# available_variables = getVariables()
+
+def get_variables_by_components(components):
+    result = {}
     try:
         with Session() as session:
-            variables = []
-            for component in available_components:
-                res = session.get_variables(component=component)
-                variables.extend(res)
-            return list(variables)
+            for comp in components:
+                result[comp] = session.get_variables(component=comp)
     except:
-        return []
+        pass
+    return result
 
 
-available_variables = getVariables()
+component_variable_map = get_variables_by_components(available_components)
+
+
+def validate_variables(ctx, param, value):
+    """
+    click callback function to validate -v/--variable value
+
+    If `-a/--all` is passed, all variables are validated and shown as valid options in the error message.
+    If `-c/--component` is passed, only relevant component variables are shown as valid options in the error message.
+    """
+    selected_components = ctx.params.get('components')
+    use_all = ctx.params.get('all')
+
+    if not value:
+        return value
+
+    # when -a/--all is used
+    if use_all or not selected_components:
+        all_vars = set(var for vars_list in component_variable_map.values() for var in vars_list)
+        invalid = [v for v in value if v not in all_vars]
+        if invalid:
+            raise click.BadParameter(f"Invalid variable: {', '.join(invalid)}. Valid options: {', '.join(all_vars)}")
+        return value
+
+    # when -c/--component is used
+    valid_vars = set()
+    for comp in selected_components:
+        valid_vars.update(component_variable_map.get(comp, []))
+
+    invalid = [v for v in value if v not in valid_vars]
+    if invalid:
+        raise click.BadParameter(f"Invalid variable{'s' if len(invalid) > 1 else ''}: {', '.join(invalid)} for selected component{'s:' if len(selected_components) > 1 else ':'} {', '.join(selected_components)}. {', '.join(invalid)}. Valid options: {', '.join(valid_vars)}")
+
+    return value
+
+
+def build_variable_help():
+    """
+    build help message for variable option
+    """
+    parts = []
+    for comp, vars_list in component_variable_map.items():
+        if vars_list:
+            vars_str = ", ".join(vars_list)
+            parts.append(f"{comp} ({vars_str})")
+    return "The variable/s to be assessed. Will be filtered by selected components. Available variables per component:\n\n" + "\n\n".join(parts)
 
 
 @click.command(short_help='assess/evaluate a specific geospatial exposure components/variables', no_args_is_help=True)
@@ -70,8 +128,8 @@ available_variables = getVariables()
     help=f'One or more components to be assessed. Valid input example: {" ".join([f"-c {var}" for var in available_components[:2]])}'
 )
 @click.option('--variables', '-v', required=False, multiple=True,
-              type=click.Choice(available_variables, case_sensitive=False),
-              help=f'The variable/s to be assessed. Valid input example: {" ".join([f"-v {var}" for var in available_variables[:2]])}' )
+              type=str, callback=validate_variables,
+              help=f"{build_variable_help()}")
 @click.option('--year', '-y', required=False, type=int, multiple=False,default=datetime.datetime.now().year,
               show_default=True,help=f'The year for which to compute population' )
 @click.option('-p', '--project',
@@ -128,6 +186,7 @@ def assess(ctx, all=False, components=None,  variables=None, year=None, project:
         logger.error(f'Project "{project}" is not a valid RAPIDA project')
         return
 
+    available_variables = list({var for vars_list in component_variable_map.values() for var in vars_list})
     if len(available_components) == 0 or len(available_variables) == 0:
         logger.warning("There are no available components. Please run `rapida init` to setup the tool first")
         sys.exit(0)


### PR DESCRIPTION
fixes #322 

### New HELP message

New assess command help message is like below. It shows valid variable names per component.

```shell
 rapida assess
Usage: rapida assess [OPTIONS]

  Assess/evaluate a specific geospatial exposure components/variables

  `-a/--all` option to assess all components (it may take longer time).

  `-c/--component` to assess only specific components.

  `-v/--variable` to assess only specific variables. If a variable is
  specified, but it is not in specified components, the variable will be
  ignored.

  `-p/--project` to assess in a specific project folder other than current
  directory.

  As default, this command tries to avoid download/compute again if they
  already exist. If you wish to redownload or recompute by force, use
  `-f/--force` flag explicitly.

  Usage:

  rapida assess --all: assess all components

  rapida assess -c rwi: assess RWI component only.

  rapida assess -c rwi -c population: assess RWI and population component only

  rapida assess -c population -v male_total -v female_total: assess only male
  and female total population.

  rapida assess -c rwi -p ./data/sample_project: assess RWI component for
  RAPIDA project stored at sample_project folder.

Options:
  -a, --all                       compute all components and variables if this
                                  option is set
  -c, --components [elegrid|roads|buildings|gdp|deprivation|landuse|population|rwi]
                                  One or more components to be assessed. Valid
                                  input example: -c elegrid -c roads
  -v, --variables TEXT            The variable/s to be assessed. Will be
                                  filtered by selected components. Available
                                  variables per component:
                                  
                                  elegrid (elegrid_length, elegrid_density)
                                  
                                  roads (roads_length, roads_count)
                                  
                                  buildings (buildings_area, nbuildings)
                                  
                                  gdp (gdp_max, gdp_min, gdp_sum, gdp_mean)
                                  
                                  deprivation (depriv_mean, depriv_min,
                                  depriv_max)
                                  
                                  landuse (built_area, crops_area)
                                  
                                  population (active_total, male_child,
                                  female_total, elderly_dependency,
                                  dependency, female_child, female_elderly,
                                  female_active, male_total, male_elderly,
                                  male_active, child_dependency,
                                  elderly_total, child_total, total)
                                  
                                  rwi (rwi_mean, rwi_max, rwi_min)
  -y, --year INTEGER              The year for which to compute population
                                  [default: 2025]
  -p, --project DIRECTORY         Optional. A project folder with rapida.json
                                  can be specified. If not, current directory
                                  is considered as a project folder.
  -f, --force                     Force assess components. Downloaded data or
                                  computed data will be ignored and
                                  recomputed.
  --debug                         Set log level to debug
  -h, --help                      Show this message and exit.

```

### Validation

- when `-c` is used

```shell
rapida assess -c roads -v roads_lengt
Usage: rapida assess [OPTIONS]
Try 'rapida assess -h' for help.

Error: Invalid value for '--variables' / '-v': Invalid variable: roads_lengt for selected component: roads. roads_lengt. Valid options: roads_length, roads_count

```

- when `-a` is used

```
 rapida assess -a -v roads_lengt
Usage: rapida assess [OPTIONS]
Try 'rapida assess -h' for help.

Error: Invalid value for '--variables' / '-v': Invalid variable: roads_lengt. Valid options: rwi_min, gdp_sum, roads_count, crops_area, nbuildings, elderly_total, female_active, female_total, elegrid_density, male_elderly, total, gdp_mean, male_child, male_active, elegrid_length, built_area, depriv_min, depriv_mean, male_total, female_child, gdp_min, child_dependency, depriv_max, rwi_mean, rwi_max, roads_length, buildings_area, child_total, active_total, gdp_max, elderly_dependency, dependency, female_elderly
```