### PR TITLE
fix download_vector bug

### DIFF
--- a/cbsurge/components/elegrid/__init__.py
+++ b/cbsurge/components/elegrid/__init__.py
@@ -181,8 +181,6 @@ class ElectricityVariable(Variable):
                     progress=progress,
                     add_polyid=False
                 )
-                lyr.SetAttributeFilter(None)
-                lyr.ResetReading()
 
             df_polygon = gpd.read_file(self.local_path, layer=project.polygons_layer_name)
             el_grid_lines = gpd.read_file(self.local_path, layer=self.component)

--- a/cbsurge/util/read_bbox.py
+++ b/cbsurge/util/read_bbox.py
@@ -84,11 +84,12 @@ def stream(src_path=None, src_layer=0, bbox=None, mask=None, batch_size=None,
                         if b.num_rows > 0:
                             if add_polyid:
                                 b = b.append_column('polyid', [polygon_id] * b.num_rows)
-                            results.append(b)
-                            nb+=b.num_rows
-                            if progress:progress.update(task, description=f'[green]Downloaded {nb} features in {polygon_id}',
-                                                        advance=nb, completed=None)
 
+                            results.append((polygon_id, b))
+                            nb+=b.num_rows
+                            if progress:
+                                progress.update(task, description=f'[green]Downloaded {nb} features in {polygon_id}',
+                                                        advance=nb, completed=None)
                         now = datetime.datetime.now()
                         delta = now-start
                         if delta.total_seconds() > 1800 and n == nb:


### PR DESCRIPTION
closes #350 

The trouble with the download was a bug that showed whenever the number of workers/threads was larger or equal to number of polygons. Due to a logical but the download_vector function exited without collecting results from the threads and thus produced empty datasets