### PR TITLE
feat: add -l/--layer option to choose layers to publish.

### DIFF
--- a/cbsurge/cli/publish.py
+++ b/cbsurge/cli/publish.py
@@ -1,6 +1,7 @@
 import os
 import click
 import logging
+import pyogrio
 from cbsurge.session import is_rapida_initialized
 from cbsurge.util.setup_logger import setup_logger
 from cbsurge.project.project import Project
@@ -8,8 +9,45 @@ from cbsurge.project.project import Project
 logger = logging.getLogger(__name__)
 
 
+def validate_layers(ctx, param, value):
+    """
+    click callback function to validate -l/--layer value.
+    This function checks whether user inputted layer names are matched to actual layer name in project GeoPackage.
+    """
+    if not value:
+        return value
+
+    project_path = ctx.params.get('project')
+    if project_path is None:
+        project_path = os.getcwd()
+    prj = Project(path=project_path)
+
+    if not prj.is_valid:
+        return value
+
+    gpkg_path = prj.geopackage_file_path
+
+    layers = pyogrio.list_layers(gpkg_path)
+    layer_names = layers[:, 0]
+
+    invalid_layers = []
+    for layer in value:
+        if not layer in layer_names:
+            invalid_layers.append(layer)
+
+    if len(invalid_layers) > 0:
+        raise click.BadParameter(f"Invalid layer{'s' if len(invalid_layers) > 1 else ''}: {', '.join(invalid_layers)}. Valid options: {", ".join(layer_names)}")
+
+    return value
+
 
 @click.command(short_help=f'publish RAPIDA project results to Azure and GeoHub')
+@click.option('-l', '--layer',
+              required=False, multiple=True,
+              default=None,
+              type=str,
+              callback=validate_layers,
+              help="Optional. Layer name to publish results to. If this option is not used, the command will convert all layers starting with stats to cloud optimized format.")
 @click.option('-p', '--project',
               default=None,
               type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
@@ -23,9 +61,13 @@ logger = logging.getLogger(__name__)
               default=False,
               help="Set log level to debug"
               )
-def publish(project: str, no_input: bool = False, debug: bool =False):
+def publish(project: str, no_input: bool = False, debug: bool =False, layer=None):
     """
     Publish project data to Azure and open GeoHub registration page URL.
+
+    As default, all layers starting with 'stats.' will be converted to cloud optimized format, and uploaded to Azure Blob Container.
+
+    Using `-l/--layer` option to select layers which you want to publish.
 
     `--no-input` option can answer yes to all prompts. Default is False.
 
@@ -34,6 +76,8 @@ def publish(project: str, no_input: bool = False, debug: bool =False):
         rapida publish: If you are already in a project folder
 
         rapida publish --project=<project folder path>: If you are not in a project folder
+
+        rapida publish -l stats.elegrid -l elegrid: publish only two layers from geopackage
 
     """
     setup_logger(name='rapida', level=logging.DEBUG if debug else logging.INFO)
@@ -50,4 +94,17 @@ def publish(project: str, no_input: bool = False, debug: bool =False):
     if not prj.is_valid:
         click.echo(f'Project "{project}" is not a valid RAPIDA project')
         return
-    prj.publish(no_input=no_input)
+
+    target_layers = layer
+    if target_layers is None or len(target_layers) == 0:
+        gpkg_path = prj.geopackage_file_path
+        layers = pyogrio.list_layers(gpkg_path)
+        layer_names = layers[:, 0]
+        stats_layers = [name for name in layer_names if name.startswith("stats.")]
+        has_stats_layers = len(stats_layers) > 0
+        if not has_stats_layers:
+            click.echo(f"Could not find assessed statistics layer in the project. Please do assess command first for at least one component.")
+            return
+        target_layers = stats_layers
+
+    prj.publish(no_input=no_input, target_layers=target_layers)


### PR DESCRIPTION
fixes #355

- as default, all layers starting with `stats.` are converted to PMTiles
- added `-l/--layer` option to allow users to choose any layers to publish. In case, users want to include non-statistics layer like `polygon`, `mask`, `buildings`, etc, this option can be used to include any layers inside geopackage.
- If users pass invalid layer name, it shows error like below

```shell
rapida publish -l stats.ele
Usage: rapida publish [OPTIONS]
Try 'rapida publish -h' for help.

Error: Invalid value for '-l' / '--layer': Invalid layer: stats.ele. Valid options: polygons, mask, elegrid, elegrid.affected, stats.elegrid
```

- the latest help message for publish command is below

```shell
rapida publish -h
Usage: rapida publish [OPTIONS]

  Publish project data to Azure and open GeoHub registration page URL.

  As default, all layers starting with 'stats.' will be converted to cloud
  optimized format, and uploaded to Azure Blob Container.

  Using `-l/--layer` option to select layers which you want to publish.

  `--no-input` option can answer yes to all prompts. Default is False.

  Usage:

      rapida publish: If you are already in a project folder

      rapida publish --project=<project folder path>: If you are not in a
      project folder

      rapida publish -l stats.elegrid -l elegrid: publish only two layers from
      geopackage

Options:
  -l, --layer TEXT         Optional. Layer name to publish results to. If this
                           option is not used, the command will convert all
                           layers starting with stats to cloud optimized
                           format.
  -p, --project DIRECTORY  Optional. A project folder with rapida.json can be
                           specified. If not, current directory is considered
                           as a project folder.
  --no-input               Optional. If True, it will automatically answer yes
                           to prompts. Default is False.
  --debug                  Set log level to debug
  -h, --help               Show this message and exit.

```