### PR TITLE
fix: fixed bug of some components to assess such as elegrid, gdp, road and landuse

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-      target: dev
+      target: prod
     image: rapida-dev:latest
     volumes:
       - ./Makefile:/rapida/Makefile
@@ -13,5 +13,8 @@ services:
       # - ~/.rapida:/root/.rapida
       # uncomment to mount data folder from local
       # - ./data:/data
+    environment:
+      # This allows the container to find the modified rapida source code in the mounted volume
+      - PYTHONPATH=/rapida
     env_file:
       - .env

--- a/rapida/components/elegrid/__init__.py
+++ b/rapida/components/elegrid/__init__.py
@@ -189,7 +189,6 @@ class ElectricityVariable(Variable):
                 input_layer_name=self.component,
                 progress=progress
             )
-            el_grid_lines.rename(columns={'h3id': 'polyid'}, inplace=True)
             el_grid_lines.to_file(self.local_path, driver='GPKG', layer=self.component, mode='w')
             self._compute_affected()
             return self.local_path
@@ -217,6 +216,17 @@ class ElectricityVariable(Variable):
 
         df_polygon = gpd.read_file(self.local_path, layer=polygons_layer)
         df_line = gpd.read_file(self.local_path, layer=self.component)
+        if 'h3id' not in df_line.columns:
+            if 'polyid' in df_line.columns:
+                df_line = df_line.rename(columns={'polyid': 'h3id'})
+            else:
+                # Legacy data without polygon id: spatial join to assign polygon ids
+                df_line = gpd.sjoin(
+                    df_line,
+                    df_polygon[['h3id', 'geometry']],
+                    how='left',
+                    predicate='intersects'
+                ).drop(columns=['index_right'], errors='ignore')
 
 
 
@@ -232,9 +242,8 @@ class ElectricityVariable(Variable):
 
             if self.operator == 'density':
                 df_polygon['area'] = df_polygon.geometry.area
-                length_sum = df_line.groupby("polyid")["geometry"].apply(lambda x: sum(x.length))
+                length_sum = df_line.groupby("h3id")["geometry"].apply(lambda x: sum(x.length))
                 length_sum_df = length_sum.reset_index(name='total_length')
-                length_sum_df.rename(columns={"polyid": "h3id"}, inplace=True)
 
                 # merge with area
                 df_polygon = df_polygon.merge(length_sum_df, on="h3id", how='left')
@@ -257,14 +266,23 @@ class ElectricityVariable(Variable):
                 if progress is not None and evaluate_task is not None:
                     progress.update(evaluate_task, description=f'[green]Computing {self.affected_layer}.')
                 df_line_affected = gpd.read_file(self.local_path, layer=self.affected_layer)
+                if 'h3id' not in df_line_affected.columns:
+                    if 'polyid' in df_line_affected.columns:
+                        df_line_affected = df_line_affected.rename(columns={'polyid': 'h3id'})
+                    else:
+                        df_line_affected = gpd.sjoin(
+                            df_line_affected,
+                            df_polygon[['h3id', 'geometry']],
+                            how='left',
+                            predicate='intersects'
+                        ).drop(columns=['index_right'], errors='ignore')
 
                 # affected density
                 if self.operator == 'density':
                     df_polygon['area'] = df_polygon.geometry.area
-                    length_sum = df_line_affected.groupby("polyid")["geometry"].apply(lambda x: sum(x.length))
+                    length_sum = df_line_affected.groupby("h3id")["geometry"].apply(lambda x: sum(x.length))
 
                     length_sum_df = length_sum.reset_index(name='total_length')
-                    length_sum_df.rename(columns={"polyid": "h3id"}, inplace=True)
 
                     # merge with area
                     df_polygon = df_polygon.merge(length_sum_df, on="h3id", how='left')

--- a/rapida/components/gdp/__init__.py
+++ b/rapida/components/gdp/__init__.py
@@ -33,6 +33,10 @@ class GdpComponent(Component):
 
 
     def __call__(self, variables: List[str] = None, target_year: int=None, **kwargs) -> str:
+        if target_year is None:
+            from datetime import date
+            target_year = date.today().year
+
         if not variables:
             variables = self.variables
         else:

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -420,11 +420,12 @@ class LanduseVariable(Variable):
         source_value = self.target_band_value
 
         calc_creation_options = {
-            "COMPRESS": "ZSTD",
+            "COMPRESS": "DEFLATE",
             "PREDICTOR": 2,
             "BIGTIFF": "IF_SAFER",
             "BLOCKXSIZE": "256",
-            "BLOCKYSIZE": "256"
+            "BLOCKYSIZE": "256",
+            "TILED": "YES"
         }
 
         def progress_callback(complete, message, user_data):

--- a/rapida/components/landuse/download.py
+++ b/rapida/components/landuse/download.py
@@ -311,9 +311,9 @@ async def download_stac(
                 creationOptions=[
                     "BLOCKXSIZE=256",
                     "BLOCKYSIZE=256",
-                    "COMPRESS=ZSTD",
+                    "COMPRESS=DEFLATE",
                     "BIGTIFF=YES",
-                    "RESAMPLING=NEAREST",
+                    "TILED=YES",
                 ],
                 callback=gdal_callback,
                 callback_data=(progress, stac_task, None)

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -478,7 +478,7 @@ class SentinelItem(object):
             dstNodata=nodata_value,
             resampleAlg='near',
             format='GTiff',
-            creationOptions=['COMPRESS=ZSTD', 'TILED=YES'],
+            creationOptions=['COMPRESS=DEFLATE', 'TILED=YES', 'BLOCKXSIZE=256', 'BLOCKYSIZE=256'],
             outputBounds=[dst_left, dst_bottom, dst_right, dst_top],  # Exact bounds
             xRes=src_pixel_size,
             yRes=src_pixel_size,

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -165,7 +165,7 @@ class SentinelItem(object):
         :param mask_layer: layer name to clip by
         """
         self.item = item
-        self._target_asset = SENTINEL2_ASSET_MAP
+        self._target_asset = SENTINEL2_ASSET_MAP.copy()
         self._target_srs = None
         self._asset_files = {}
         self.mask_file = mask_file
@@ -246,7 +246,7 @@ class SentinelItem(object):
 
         try:
             loop = asyncio.get_event_loop()
-            loop.run_until_complete(
+            downloaded_paths = loop.run_until_complete(
                 download_remote_files(
                     file_urls=file_urls,
                     dst_folder=download_dir,
@@ -254,6 +254,27 @@ class SentinelItem(object):
                     progress=progress, force=force
                 )
             )
+
+            # Normalize asset file paths using actual downloaded file locations.
+            resolved_asset_files = {}
+            for path in downloaded_paths:
+                file_name = os.path.basename(path)
+                band_name, _ = os.path.splitext(file_name)
+                if band_name in self._asset_files:
+                    resolved_asset_files[band_name] = path
+
+            if resolved_asset_files:
+                self._asset_files.update(resolved_asset_files)
+
+            missing_required_bands = [
+                band_name
+                for band_name in LandusePrediction.required_bands
+                if band_name not in self._asset_files or not os.path.exists(self._asset_files[band_name])
+            ]
+            if missing_required_bands:
+                raise FileNotFoundError(
+                    f"{self.id}: Missing required landuse band files after download: {', '.join(missing_required_bands)}"
+                )
 
             # once all downloads are successfully done, write item.json in the folder
             # While item.json not real imagery data it contains some extracted medatada which can be usewful

--- a/rapida/components/landuse/stac_collection.py
+++ b/rapida/components/landuse/stac_collection.py
@@ -265,7 +265,7 @@ class StacCollection(object):
             return [gpd.GeoSeries([merged], crs=3857).to_crs(original_crs).iloc[0]]
 
         # Generate internal grid points spaced equally based on scene size
-        minx, miny, maxx, maxy = merged.bounds_from_file
+        minx, miny, maxx, maxy = merged.bounds
         # create double size of scene to be able to cover the whole scene area
         spacing = scene_size * 2
         nx = int(np.ceil((maxx - minx) / spacing))

--- a/rapida/components/roads/__init__.py
+++ b/rapida/components/roads/__init__.py
@@ -242,17 +242,12 @@ class RoadsVariable(Variable):
 
             if self.operator == 'density':
                 df_polygon['area'] = df_polygon.geometry.area
-                length_sum = df_line.groupby("polyid")["geometry"].apply(lambda x: sum(x.length))
-                length_sum_df = length_sum.reset_index(name='total_length')
-                length_sum_df.rename(columns={"polyid": "h3id"}, inplace=True)
-
-
-
-                # merge with area
-                df_polygon = df_polygon.merge(length_sum_df, on="h3id", how='left')
-
-                df_polygon[self.name] = df_polygon['total_length'] / df_polygon['area']
-                df_polygon.drop(columns=['total_length', 'area'], inplace=True)
+                length_by_polyid = df_line.groupby("polyid")["geometry"].apply(lambda x: x.length.sum())
+                total_length = df_polygon["h3id"].map(length_by_polyid).fillna(0.0)
+                df_polygon[self.name] = (total_length / df_polygon['area']) \
+                    .replace([float("inf"), float("-inf")], 0.0) \
+                    .fillna(0.0)
+                df_polygon.drop(columns=['area'], inplace=True)
                 output_df = df_polygon
             else:
 
@@ -277,17 +272,13 @@ class RoadsVariable(Variable):
 
                 if self.operator == 'density':
                     df_polygon['area'] = df_polygon.geometry.area
-                    length_sum = df_line_affected.groupby("polyid")["geometry"].apply(lambda x: sum(x.length))
-
-                    length_sum_df = length_sum.reset_index(name='total_length')
-                    length_sum_df.rename(columns={"polyid": "h3id"}, inplace=True)
-
-                    # merge with area
-                    df_polygon = df_polygon.merge(length_sum_df, on="h3id", how='left')
-
-                    df_polygon[self.affected_variable] = df_polygon['total_length'] / df_polygon['area']
+                    length_by_polyid = df_line_affected.groupby("polyid")["geometry"].apply(lambda x: x.length.sum())
+                    total_length = df_polygon["h3id"].map(length_by_polyid).fillna(0.0)
+                    df_polygon[self.affected_variable] = (total_length / df_polygon['area']) \
+                        .replace([float("inf"), float("-inf")], 0.0) \
+                        .fillna(0.0)
                     # drop columns
-                    df_polygon.drop(columns=['total_length', 'area'], inplace=True)
+                    df_polygon.drop(columns=['area'], inplace=True)
                     output_df = df_polygon
                     # testing purposes
                     for i, row in output_df.iterrows():

--- a/rapida/util/download_remote_file.py
+++ b/rapida/util/download_remote_file.py
@@ -256,13 +256,15 @@ async def download_remote_files(
             for file_url in file_urls:
                 if target_path_func is not None:
                     target_path = target_path_func(file_url, dst_folder)
-                    new_dirname = os.path.dirname(target_path)
-                    if new_dirname != dst_folder:
-                        os.makedirs(new_dirname, exist_ok=True)
-                    file_name = os.path.basename(target_path)
+                    if target_path is None:
+                        raise ValueError(f"target_path_func returned None for URL: {file_url}")
                 else:
                     file_name = os.path.basename(file_url)
-                target_path = os.path.join(dst_folder, file_name)
+                    target_path = os.path.join(dst_folder, file_name)
+
+                target_dir = os.path.dirname(target_path)
+                if target_dir:
+                    os.makedirs(target_dir, exist_ok=True)
 
                 tasks.append(
                     asyncio.create_task(

--- a/rapida/util/gpd_overlay.py
+++ b/rapida/util/gpd_overlay.py
@@ -55,7 +55,7 @@ def process_chunk(chunk_rows, overlay_df, overlay_df_sindex, crs):
         single_row_gdf = gpd.GeoDataFrame([row], geometry='geometry', crs=crs)
         poly_geom = single_row_gdf.geometry.iloc[0]
 
-        possible_matches_index = list(overlay_df_sindex.intersection(poly_geom.bounds_from_file))
+        possible_matches_index = list(overlay_df_sindex.intersection(poly_geom.bounds))
         possible_matches = overlay_df.iloc[possible_matches_index]
         precise_matches = possible_matches[possible_matches.intersects(poly_geom)].copy()
         precise_matches.loc[:, "geometry"] = precise_matches.geometry.intersection(poly_geom)


### PR DESCRIPTION
When I ran `rapida assess --all`, I found some following components are not working.

- elegrid
- gdp
- road
- landuse

For landuse, I realized ZSTD compression cannot be opened by QGIS (QGIS4 shows invalid source). I feel it is inconvenient to be unable to confirm landuse in QGIS. I changed ZSTD to DEFLATE.

Now I can ran `rapida assess --all` and `rapida assess -c landuse`. I realized landuse was excluded from `--all` because it takes long time.

## Commits

- bb4c957 fix: changed ZSTD to DEFLATE for landuse's output. So QGIS can open it
- 29b52a6 fix: fixed bug of landuse components to correct download path
- 7c8fa01 fix: fixed docker-compose.dev.yaml
- 772e3d7 fix: fixed bugs of elegrid, gdp and road components