### PR TITLE
fix: removed uvloop entirely

### DIFF
--- a/rapida/cli/__init__.py
+++ b/rapida/cli/__init__.py
@@ -22,6 +22,7 @@ import uvloop
 import asyncio
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 

--- a/rapida/cli/__init__.py
+++ b/rapida/cli/__init__.py
@@ -18,12 +18,6 @@ from rich.progress import Progress
 import click
 import nest_asyncio
 nest_asyncio.apply()
-import uvloop
-import asyncio
-
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-asyncio.set_event_loop(asyncio.new_event_loop())
-
 
 
 


### PR DESCRIPTION
fixes #519 `RuntimeError: There is no current event loop` in sync component code paths

### Problem

`rapida assess -c population` crashes immediately:

```
File "/rapida/rapida/components/population/init.py", line 387, in download_compute
downloaded_files = asyncio.run(download_remote_files(...))
File ".../uvloop/init.py", line 206, in get_event_loop
raise RuntimeError(
RuntimeError: There is no current event loop in thread 'MainThread'.
sys:1: RuntimeWarning: coroutine 'download_remote_files' was never awaited
```

### Cause

The asyncio bootstrap in `rapida/cli/__init__.py`:

- `nest_asyncio.apply()` replaces `asyncio.run` with a version that reuses the current loop via `get_event_loop()` — it never creates one itself.
- The uvloop policy installed right after it raises `RuntimeError` instead of implicitly creating a loop (uvloop 0.22 behaviour).
- `assess` is a synchronous Click command, so there is neither a running loop nor a registered one, and every `asyncio.run(...)` on a sync path fails.

### Fix

remove uvloop entirely

```diff
- asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
```
