### PR TITLE
fix: pixi setup for macos

### DIFF
--- a/deploy/pixi.toml
+++ b/deploy/pixi.toml
@@ -1,7 +1,14 @@
 [workspace]
 name = "rapida"
 channels = ["conda-forge"]
-platforms = ["linux-64", "win-64", "osx-arm64"]
+platforms = [
+    "linux-64",
+    "win-64",
+    # pyvalhalla only ships a macosx_14_0_arm64 wheel; without raising the macOS floor
+    # pixi considers it incompatible and falls back to building it from source, which
+    # fails in CMake (prime_server not found).
+    { platform = "osx-arm64", macos = "14.0" },
+]
 
 [dependencies]
 # Heavy binary geospatial drivers and libraries

--- a/rapida/ntl/noaa/cmask.py
+++ b/rapida/ntl/noaa/cmask.py
@@ -312,11 +312,13 @@ def cloud_coverage(hdf_url: str, bbox: list) -> int:
     gdal.PushErrorHandler('CPLQuietErrorHandler')
 
     # --- 1. DYNAMIC DRIVER SELECTION ---
-    is_windows = platform.system() == "Windows"
+    # GDAL's netCDF driver can only read /vsi paths on Linux (it needs userfaultfd).
+    # On Windows and macOS we skip it and drive the HDF5 driver directly instead.
+    use_hdf5_driver = platform.system() != "Linux"
 
-    if is_windows:
+    if use_hdf5_driver:
         gdal.SetConfigOption('GDAL_SKIP', 'netCDF')
-        # On Windows, we force the HDF5 driver and its specific string syntax
+        # On Windows and MacOS, we force the HDF5 driver and its specific string syntax
         base_ds = f'HDF5:"/vsicurl/{hdf_url}"'
         mask_str = f'{base_ds}://CloudMaskBinary'
         lon_str = f'{base_ds}://Longitude'


### PR DESCRIPTION
Now it works in my MacOS 

- setup

```
pixi install
```

- ntl search with --cm

```
 pixi run rapida ntl search noaa -b -72.3,7.5,-64.16,13.72 --date 2026-07-10 -cm        
✨ Pixi task (rapida): dotenv -e .env rapida ntl search noaa -b -72.3,7.5,-64.16,13.72 --date 2026-07-10 -cm
/Users/j_igarashi/Documents/git/UNDP-Data/rapida/deploy/.pixi/envs/default/lib/python3.12/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
  _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
[08/09/26 10:57:48] INFO     Skipping DescendingPass: SNPP-202607100504 because of low elevation angle 13.664044                                                                                       search.py:396
[08/09/26 10:57:57] INFO     Skipping DescendingPass: N21-202607100429 because of low elevation angle 4.678326                                                                                         search.py:396
[08/09/26 10:58:00] INFO     Skipping DescendingPass: N21-202607100749 because of low elevation angle 2.797944                                                                                         search.py:396
Computing cloud coverage ....  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--/Users/j_igarashi/Documents/git/UNDP-Data/rapida/deploy/.pixi/envs/default/lib/python3.12/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
  _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
/Users/j_igarashi/Documents/git/UNDP-Data/rapida/deploy/.pixi/envs/default/lib/python3.12/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
  _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
/Users/j_igarashi/Documents/git/UNDP-Data/rapida/deploy/.pixi/envs/default/lib/python3.12/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
  _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
/Users/j_igarashi/Documents/git/UNDP-Data/rapida/deploy/.pixi/envs/default/lib/python3.12/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 2.2.0 when it was built against 2.1.0, this may cause problems
  _warn(("h5py is running against HDF5 {0} when it was built against {1}, "
                                      VIIRS satellites granules for the night of  2026-07-10 covering (-72.3, 7.5, -64.16, 13.72)                                       
┏━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Position ┃ Satellite ┃ Timestamp (UTC) ┃ Bbox offset from SSP (km) ┃ Elevation above bbox (degrees) ┃ Cloud coverage in bbox (%) ┃ Score (%) ┃ BBOX intersection (%) ┃
┡━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│    1     │    N21    │  202607100609   │            115            │             80.81              │             89             │    42     │          81           │
│    2     │   SNPP    │  202607100644   │            798            │             39.82              │             88             │    24     │          75           │
│    3     │    N20    │  202607100523   │           1191            │             26.91              │             93             │    15     │          43           │
│    4     │    N20    │  202607100703   │           1443            │             20.95              │             96             │    11     │          35           │
└──────────┴───────────┴─────────────────┴───────────────────────────┴────────────────────────────────┴────────────────────────────┴───────────┴───────────────────────┘
```